### PR TITLE
node name set to just the vm name works as well

### DIFF
--- a/jobs/cloud-provider/templates/bin/cloud-provider_utils.erb
+++ b/jobs/cloud-provider/templates/bin/cloud-provider_utils.erb
@@ -4,7 +4,7 @@ set_node_name() {
   node_name="<%= spec.ip %>"
 <% if_p("cloud-provider.type") do | provider_type | %>
   <% if provider_type == "gce" %>
-  node_name="$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google").c.<%= p("cloud-provider.gce.project-id") %>.internal"
+  node_name="$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google")"
   <% end %>
 <% end %>
 }


### PR DESCRIPTION
I ran into an issue with my node name being too long (vm-<gcp assigned uuid>.c.<project id>.internal). kubectl refused to register my worker node. See #145 for more details and logs. The worker registered fine after this change.