### PR TITLE
Kube-proxy needs cluster-cidr

### DIFF
--- a/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
+++ b/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
@@ -29,6 +29,7 @@ start_kubernetes_proxy() {
   kube-proxy \
     --hostname-override=<%= spec.ip %> \
     --master=<%= p("kubernetes-api-url") %> \
+    --cluster-cidr=10.200.0.0/16 \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --proxy-mode=iptables \
     --v=2 \


### PR DESCRIPTION
Nodes can't access service clusterIPs or pod IPs without Kube-Proxy knowing the cluster CIDR (verified Kubo 0.7.0+)