### PR TITLE
Expose kubelet resource reservation flags.

### DIFF
--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -33,6 +33,15 @@ properties:
   port:
     example: 81
     default: 4567
+  kube-reserved:
+    description: Resource reservations for kubernetes system daemons
+    example: "cpu=1,memory=2Gi,storage=1Gi"
+  system-reserved:
+    description: Resource reservations for OS system daemons
+    example: "cpu=500m,memory=1Gi,storage=1Gi"
+  eviction-hard:
+    description: Node eviction thresholds
+    example: "memory.available<500Mi,nodefs.available<10%"
 
 provides:
 - name: kubernetes-workers

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -61,6 +61,9 @@ start_kubelet() {
     --tls-private-key-file=/var/vcap/jobs/kubelet/config/kubelet-key.pem \
     --network-plugin=cni \
     --cni-bin-dir=/var/vcap/jobs/kubelet/packages/cni/bin \
+    <% if_p('kube-reserved') do |kube_reserved| %>--kube-reserved="<%= kube_reserved %>"<% end %> \
+    <% if_p('system-reserved') do |system_reserved| %>--system-reserved="<%= system_reserved %>"<% end %> \
+    <% if_p('eviction-hard') do |eviction_hard| %>--eviction-hard="<%= eviction_hard %>"<% end %> \
     --require-kubeconfig=true \
     --v=2 \
     --node-labels=spec.ip=<%= spec.ip %> \


### PR DESCRIPTION
See
https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources.

Note--the kubelet takes a lot of flags that aren't exposed here, so it might also make sense to add a `flags` hash for arbitrary non-default flags instead of taking this approach:

```
<% p('flags').each do |key, value| %>
--<%= key %>="<%= value %>" \
<% end %>
```

WDYT?