### PR TITLE
support 'nats' link that is already implemented in template

### DIFF
--- a/jobs/route-sync/spec
+++ b/jobs/route-sync/spec
@@ -28,7 +28,7 @@ properties:
     app_domain:
       description: "Cloud Foundry apps domain"
       example: app.cf.cf-app.com
- 
+
   nats.machines:
     description: IPs of each NATS cluster member
     example: |
@@ -36,13 +36,16 @@ properties:
       - 192.168.52.123
   nats.port:
     description: TCP port of NATS servers
-    default: 4222
+    example: 4222
   nats.user:
     description: User name for NATS authentication
-    default: nats
+    example: nats
   nats.password:
     description: Password for NATS authentication
 
 consumes:
 - name: kubernetes-workers
   type: kubernetes-workers
+- name: nats
+  type: nats
+  optional: true


### PR DESCRIPTION
The dual use of `p('nats.xyz')` and `link('nats')` is already in the template; but the `nats` link is not supported in the spec. This is fixed in this PR.

Just like https://github.com/cloudfoundry-incubator/routing-release/blob/develop/jobs/route_registrar/spec this requires that we do not provide default values for `nats.port` etc in the `spec` file.

This will not break kubo-deployment which is currently explicitly setting all properties in its `cf-routing.yml`.

One this PR is merged, we can switch to using `nats` link in `cf-routing.yml`.