### PR TITLE
Check UAA authentication without hiding error messages [fixes #135]

### DIFF
--- a/jobs/kubernetes-api-route-registrar/templates/bin/announce_route.erb
+++ b/jobs/kubernetes-api-route-registrar/templates/bin/announce_route.erb
@@ -15,6 +15,9 @@ BACKEND_PORT="<%=p('backend_port') %>"
 BACKEND_IP="<%= spec.ip %>"
 KUBO_PORT="<%=p('external_kubo_port') %>"
 
+# Check the credentials. Print errors to logs.
+curl --max-time 10 -s -k -X POST ${UAA_API_URL}/oauth/token --data "client_id=${UAA_CLIENT_ID}&client_secret=${UAA_CLIENT_SECRET}&grant_type=client_credentials&response_type=token"
+
 # Fetch UAA token
 UAA_REQUEST=$(curl --fail --max-time 10 -s -k -X POST ${UAA_API_URL}/oauth/token --data "client_id=${UAA_CLIENT_ID}&client_secret=${UAA_CLIENT_SECRET}&grant_type=client_credentials&response_type=token")
 UAA_TOKEN=$(echo ${UAA_REQUEST} | jq -r .access_token)


### PR DESCRIPTION
Since the instructions for configuring the UAA client are manual in https://docs-cfcr.cfapps.io/installing/cf-routing/#step-3-configure-cfcr-for-cloud-foundry-routing there is a high chance of humans getting this wrong (e.g. me).

I would like to strongly advocate for us returning the UAA API error into the logs if there is one.