### PR TITLE
don't rely on IPs being unique across whole VCenter DC

### DIFF
--- a/jobs/kubelet/templates/bin/pre-start.erb
+++ b/jobs/kubelet/templates/bin/pre-start.erb
@@ -33,7 +33,9 @@ update_vsphere_vms() {
    export GOVC_PASSWORD="$(get_cloud_property "password")"
    export GOVC_INSECURE="$(get_cloud_property "insecure-flag")"
 
-   /var/vcap/packages/govc/bin/govc vm.change -e 'disk.enableUUID=1' -vm.ip=<%= spec.ip %>
+   # how to get the vm uuid and why we need this is described in https://kubernetes.io/docs/getting-started-guides/vsphere/#enable-vsphere-cloud-provider
+   local vm_uuid=$(cat /sys/class/dmi/id/product_serial | sed -e 's/^VMware-//' -e 's/-/ /' | awk '{ print tolower($1$2$3$4 "-" $5$6 "-" $7$8 "-" $9$10 "-" $11$12$13$14$15$16) }')
+   /var/vcap/packages/govc/bin/govc vm.change -e 'disk.enableUUID=1' -vm.uuid=$vm_uuid
 }
 
 main() {


### PR DESCRIPTION
fixes #129 

remarks:
- uses uniqueness of vm uuid across VSphere
- since pre start runs as root, we can get the uuid from sysfs
- successfully tested on our kubo deployment on vsphere; the flag is set to `1` and `/var/vcap/sys/log/kubelet/pre-start.stderr.log` shows the following:
```
++ cat /sys/class/dmi/id/product_serial
++ sed -e 's/^VMware-//' -e 's/-/ /'
++ awk '{ print tolower($1$2$3$4 "-" $5$6 "-" $7$8 "-" $9$10 "-" $11$12$13$14$15$16) }'
+ local vm_uuid=420ce004-ea89-b8f5-34d6-d44f58a3f251
+ /var/vcap/packages/govc/bin/govc vm.change -e disk.enableUUID=1 -vm.uuid=420ce004-ea89-b8f5-34d6-d44f58a3f251
```