### PR TITLE
Require etcd-quorum-read

### DIFF
--- a/jobs/kubernetes-api/templates/bin/kubernetes_api_ctl.erb
+++ b/jobs/kubernetes-api/templates/bin/kubernetes_api_ctl.erb
@@ -66,6 +66,7 @@ start_kubernetes_api_server() {
       --cloud-provider=${cloud_provider} \
       --cloud-config="${cloud_config}" \
       --enable-swagger-ui=true \
+      --etcd-quorum-read=true \
       --etcd-servers=<%= etcd_endpoints %> \
       --insecure-bind-address=127.0.0.1 \
       --kubelet-https=true \


### PR DESCRIPTION
This will be default behaviour for Kubernetes-1.9

https://github.com/kubernetes/kubernetes/pull/53717