### PR TITLE
Optionally disable creation of ingress rules on worker security groups

### DIFF
--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -84,6 +84,19 @@ properties:
     default: ''
 
   # AWS specific properties
+  cloud-provider.aws.vpc:
+    description: |
+      The AWS VPC flag enables the possibility to run the master components
+      on a different aws account, on a different cloud provider or on-premises.
+      If this is set cloud-provider.aws.kubernetes-cluster-tag must be provided
+  cloud-provider.aws.subnet-id:
+    description: Enables using a specific subnet to use for ELB's
+  cloud-provider.aws.route-table-id:
+    description: Enables using a specific RouteTable
+  cloud-provider.aws.kubernetes-cluster-tag:
+    description: the legacy cluster id we'll use to identify our cluster resources
+  cloud-provider.aws.kubernetes-cluster-id:
+    description: the cluster id we'll use to identify our cluster resourcess
   cloud-provider.aws.disable-security-group-ingress:
     description: |
       Kubernetes amends the ingress rules on security groups bound to workers to allow access to ELBs.
@@ -91,3 +104,8 @@ properties:
 
       This can also be used as workaround to bugs such as - https://github.com/kubernetes/kubernetes/issues/17626
     default: false
+  cloud-provider.aws.elb-security-group:
+    description: |
+      AWS has a hard limit of 500 security groups. For large clusters creating a security group for each ELB
+      can cause the max number of security groups to be reached. If this is set instead of creating a new
+      Security group for each ELB this security group will be used instead.

--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -18,7 +18,7 @@ provides:
 properties:
   cloud-provider.type:
     description: "Type of Cloud Provider to use"
-    example: gce, vsphere
+    example: gce, vsphere, aws
 
   # GCE specific properties
   cloud-provider.gce.project-id:
@@ -82,3 +82,12 @@ properties:
   cloud-provider.openstack.ca-file:
     description: CA file to connect to your OpenStack cluster (Optional).
     default: ''
+
+  # AWS specific properties
+  cloud-provider.aws.disable-security-group-ingress:
+    description: |
+      Kubernetes amends the ingress rules on security groups bound to workers to allow access to ELBs.
+      This has scaling limits with number of rules allowed in a Security Group. If you set this you will need to make sure you open up your workers' security group from ELBs via another means.
+
+      This can also be used as workaround to bugs such as - https://github.com/kubernetes/kubernetes/issues/17626
+    default: false

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -38,6 +38,9 @@
       cloud_config['domain-name'] = p('cloud-provider.openstack.domain-name')
       cloud_config['region'] = p('cloud-provider.openstack.region')
       cloud_config['ca-file'] = p('cloud-provider.openstack.ca-file')
+    elsif provider_type == 'aws'
+      cloud_config_string = "[Global]\n"
+      cloud_config['disable-security-group-ingress'] = p('cloud-provider.aws.disable-security-group-ingress')
     end
 
     cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -11,7 +11,7 @@
       cloud_config['project-id'] = p('cloud-provider.gce.project-id')
       cloud_config['network-name'] = p('cloud-provider.gce.network-name')
       if_p('cloud-provider.gce.service_key') { cloud_config['token-url'] = 'nil' }
-      if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag  }
+      if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag }
     elsif provider_type == 'vsphere'
       cloud_config_string = "[Global]\n"
       cloud_config['user'] = p('cloud-provider.vsphere.user').gsub('\\','\\\\\\')
@@ -40,7 +40,13 @@
       cloud_config['ca-file'] = p('cloud-provider.openstack.ca-file')
     elsif provider_type == 'aws'
       cloud_config_string = "[Global]\n"
-      cloud_config['DisableSecurityGroupIngress'] = p('cloud-provider.aws.disable-security-group-ingress')
+      if_p('cloud-provider.aws.vpc') { |vpc| cloud_config['VPC'] = vpc }
+      if_p('cloud-provider.aws.subnet-id') { |id| cloud_config['SubnetID'] = id }
+      if_p('cloud-provider.aws.route-table-id') { |id| cloud_config['RouteTableID'] = id }
+      if_p('cloud-provider.aws.kubernetes-cluster-tag') { |tag| cloud_config['KubernetesClusterTag'] = tag }
+      if_p('cloud-provider.aws.kubernetes-cluster-id') { |id| cloud_config['KubernetesClusterID'] = id }
+      if_p('cloud-provider.aws.disable-security-group-ingress') { |disable_sec_group_ingress| cloud_config['DisableSecurityGroupIngress'] = disable_sec_group_ingress }
+      if_p('cloud-provider.aws.elb-security-group') { |elb_sec_group| cloud_config['ElbSecurityGroup'] = elb_sec_group }
     end
 
     cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -40,7 +40,7 @@
       cloud_config['ca-file'] = p('cloud-provider.openstack.ca-file')
     elsif provider_type == 'aws'
       cloud_config_string = "[Global]\n"
-      cloud_config['disable-security-group-ingress'] = p('cloud-provider.aws.disable-security-group-ingress')
+      cloud_config['DisableSecurityGroupIngress'] = p('cloud-provider.aws.disable-security-group-ingress')
     end
 
     cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }

--- a/spec/cloud_provider_ini_spec.rb
+++ b/spec/cloud_provider_ini_spec.rb
@@ -91,4 +91,46 @@ describe 'cloud-provider-ini' do
       end
     end
   end
+
+  context 'if cloud provider is aws' do
+    let(:properties) { {'cloud-provider' => { 'type' => 'aws', 'aws' => aws_config }} }
+
+    context 'optional properties provided' do
+      let(:aws_config) do
+        {
+          'vpc' => 'fake-vpc',
+          'subnet-id' => 'fake-subnet-id',
+          'route-table-id' => 'fake-route-table-id',
+          'kubernetes-cluster-tag' => 'fake-kubernetes-cluster-tag',
+          'kubernetes-cluster-id' => 'fake-kubernetes-cluster-id',
+          'disable-security-group-ingress' => true,
+          'elb-security-group' => 'fake-elb-security-group'
+        }
+      end
+
+      let(:key_map) do
+        {
+          'vpc' => 'VPC',
+          'subnet-id' => 'SubnetID',
+          'route-table-id' => 'RouteTableID',
+          'kubernetes-cluster-tag' => 'KubernetesClusterTag',
+          'kubernetes-cluster-id' => 'KubernetesClusterID',
+          'disable-security-group-ingress' => 'DisableSecurityGroupIngress',
+          'elb-security-group' => 'ElbSecurityGroup'
+        }
+      end
+
+      it 'renders the correct template for aws' do
+        aws_config.each { |k,v| expect(rendered_template).to include("#{key_map[k]}=#{v}") }
+      end
+    end
+
+    context 'optional properties not provided' do
+      let(:aws_config) {{}}
+
+      it 'renders the correct template for aws' do
+        expect(rendered_template).to eq("\n[Global]\nDisableSecurityGroupIngress=false\n\n\n")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Kubernetes amends the ingress rules on security groups bound to workers to allow access to ELBs.
This has scaling limits with number of rules allowed in a Security Group. If you set this you will need to make sure you open up your workers' security group from ELBs via another means.

This can also be used as workaround to bugs such as - https://github.com/kubernetes/kubernetes/issues/17626