### PR TITLE
Feature/openstack provider

### DIFF
--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -18,7 +18,7 @@ provides:
 properties:
   cloud-provider.type:
     description: "Type of Cloud Provider to use"
-    example: gce, vsphere
+    example: gce, vsphere, openstack
 
   # GCE specific properties
   cloud-provider.gce.project-id:
@@ -54,3 +54,32 @@ properties:
   cloud-provider.vsphere.scsicontrollertype:
     description: vSphere vSCSI adapter type name
     default: pvscsi
+
+# Openstack specific properties
+  cloud-provider.openstack.username:
+    description:  Refers to the username of a valid user set in keystone
+  cloud-provider.openstack.password:
+    description: Refers to the password of a valid user set in keystone
+  cloud-provider.openstack.auth-url:
+    description: The URL of the keystone API used to authenticate. On OpenStack control panels, this can be found at Access and Security > API Access > Credentials.
+  cloud-provider.openstack.region:
+    description: Used to specify the identifier of the region to use when running on a multi-region OpenStack cloud (Optional)
+  cloud-provider.openstack.tenant-id:
+    description: Used to specify the id of the project where you want to create your resources
+  cloud-provider.openstack.tenant-name:
+    description: Used to specify the name of the project where you want to create your resources (Optional)
+  cloud-provider.openstack.trust-id:
+    description: Used to specify the identifier of the trust to use for authorization.  Available trusts are found under the /v3/OS-TRUST/trusts endpoint of the Keystone API.(Optional)
+  cloud-provider.openstack.domain-id:
+    description: Used to specify the id of the domain your user belongs to (Optional)
+  cloud-provider.openstack.domain-name:
+    description: Used to specify the name of the domain your user belongs to (Optional)
+  cloud-provider.openstack.bs-version:
+    description: Block-storage version. Valid values are v1, v2, v3 and auto
+    default: auto
+  cloud-provider.openstack.trust-device-path:
+    description: By default block device names provided by Cinder (e.g. /dev/vda) can not be trusted. True toggle this behavior
+    default: false
+  cloud-provider.openstack.ignore-volume-az:
+    description:  When Nova and Cinder have different availability zones, this should be set to true.
+    default: false

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -14,7 +14,7 @@
       if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag  }
     elsif provider_type == 'vsphere'
       cloud_config_string = "[Global]\n"
-      cloud_config['user'] = p('cloud-provider.vsphere.user').gsub('\\','\\\\\\') 
+      cloud_config['user'] = p('cloud-provider.vsphere.user').gsub('\\','\\\\\\')
       cloud_config['password'] = p('cloud-provider.vsphere.password')
       cloud_config['server'] = p('cloud-provider.vsphere.server')
       cloud_config['port'] = p('cloud-provider.vsphere.port')
@@ -26,6 +26,22 @@
 
       disk_config_string="[Disk]\n"
       disk_config['scsicontrollertype'] = p('cloud-provider.vsphere.scsicontrollertype')
+    elsif provider_type == 'openstack'
+      cloud_config_string = "[Global]\n"
+      cloud_config['auth-url'] = p('cloud-provider.openstack.auth-url')
+      cloud_config['username'] = p('cloud-provider.openstack.username')
+      cloud_config['password'] = p('cloud-provider.openstack.password')
+      cloud_config['tenant-id'] = p('cloud-provider.openstack.tenant-id')
+      if_p('cloud-provider.openstack.region') { cloud_config['region'] = p('cloud-provider.openstack.region') }
+      if_p('cloud-provider.openstack.tenant-name') { cloud_config['tenant-name'] = p('cloud-provider.openstack.tenant-name') }
+      if_p('cloud-provider.openstack.trust-id') { cloud_config['trust-id'] = p('cloud-provider.openstack.trust-id') }
+      if_p('cloud-provider.openstack.domain-id') { cloud_config['domain-id'] = p('cloud-provider.openstack.domain-id') }
+      if_p('cloud-provider.openstack.domain-name') { cloud_config['domain-name'] = p('cloud-provider.openstack.domain-name') }
+
+      disk_config_string="[Disk]\n"
+      if_p('cloud-provider.openstack.bs-version') { cloud_config['bs-version'] = p('cloud-provider.openstack.bs-version') }
+      if_p('cloud-provider.openstack.trust-device-path') { cloud_config['trust-device-path'] = p('cloud-provider.openstack.trust-device-path') }
+      if_p('cloud-provider.openstack.ignore-volume-az') { cloud_config['ignore-volume-az'] = p('cloud-provider.openstack.ignore-volume-az') }
     end
 
     cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -38,10 +38,10 @@
       if_p('cloud-provider.openstack.domain-id') { cloud_config['domain-id'] = p('cloud-provider.openstack.domain-id') }
       if_p('cloud-provider.openstack.domain-name') { cloud_config['domain-name'] = p('cloud-provider.openstack.domain-name') }
 
-      disk_config_string="[Disk]\n"
-      if_p('cloud-provider.openstack.bs-version') { cloud_config['bs-version'] = p('cloud-provider.openstack.bs-version') }
-      if_p('cloud-provider.openstack.trust-device-path') { cloud_config['trust-device-path'] = p('cloud-provider.openstack.trust-device-path') }
-      if_p('cloud-provider.openstack.ignore-volume-az') { cloud_config['ignore-volume-az'] = p('cloud-provider.openstack.ignore-volume-az') }
+      disk_config_string="[BlockStorage]\n"
+      if_p('cloud-provider.openstack.bs-version') { disk_config['bs-version'] = p('cloud-provider.openstack.bs-version') }
+      if_p('cloud-provider.openstack.trust-device-path') { disk_config['trust-device-path'] = p('cloud-provider.openstack.trust-device-path') }
+      #if_p('cloud-provider.openstack.ignore-volume-az') { disk_config['ignore-volume-az'] = p('cloud-provider.openstack.ignore-volume-az') }
     end
 
     cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }


### PR DESCRIPTION
Adding Openstack cloud-provider

This PR is different from https://github.com/cloudfoundry-incubator/kubo-release/pull/106

As this one include volume provisioning.

In order to make Openstack cloud provider working you need to disable on bosh human readables vm see PR https://github.com/cloudfoundry/bosh-deployment/pull/172

Tested on Mitaka / keystone v2 and v3

![image](https://user-images.githubusercontent.com/4757816/34399686-0e15ba7a-ebcd-11e7-9955-c08cacdfc164.png)


