### PR TITLE
Ca file required a file

### DIFF
--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -5,6 +5,7 @@ templates:
   config/cloud-provider.ini.erb: config/cloud-provider.ini
   config/service_key.json.erb: config/service_key.json
   bin/cloud-provider_utils.erb: bin/cloud-provider_utils
+  config/openstack-ca.crt.erb: config/openstack-ca.crt
 
 packages:
 - pid_utils
@@ -81,7 +82,6 @@ properties:
     default: ''
   cloud-provider.openstack.ca-file:
     description: CA file to connect to your OpenStack cluster (Optional).
-    default: ''
   cloud-provider.openstack.bs-version:
     description: Block-storage version. Valid values are v1, v2, v3 and auto. Default to auto (Optional).
     default: auto

--- a/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
+++ b/jobs/cloud-provider/templates/config/cloud-provider.ini.erb
@@ -37,7 +37,7 @@
       cloud_config['domain-id'] = p('cloud-provider.openstack.domain-id')
       cloud_config['domain-name'] = p('cloud-provider.openstack.domain-name')
       cloud_config['region'] = p('cloud-provider.openstack.region')
-      cloud_config['ca-file'] = p('cloud-provider.openstack.ca-file')
+      if_p('cloud-provider.openstack.ca-file') { cloud_config['ca-file'] = '/var/vcap/jobs/cloud-provider/config/openstack-ca.crt' }
 
       disk_config_string="[BlockStorage]\n"
       disk_config['bs-version'] = p('cloud-provider.openstack.bs-version')

--- a/jobs/cloud-provider/templates/config/openstack-ca.crt.erb
+++ b/jobs/cloud-provider/templates/config/openstack-ca.crt.erb
@@ -1,0 +1,3 @@
+<% if_p('cloud-provider.openstack.ca-file') do |ca_file| -%>
+<%= ca_file %>
+<% end -%>

--- a/spec/cloud_provider_ini_spec.rb
+++ b/spec/cloud_provider_ini_spec.rb
@@ -59,7 +59,7 @@ describe 'cloud-provider-ini' do
          'domain-id' => 'fake-domain-id',
          'domain-name' => 'fake-domain-name',
          'region' => 'fake-region',
-         'ca-file' => 'fake-ca-file',
+         'ca-file' => 'fake-perm-file',
          'bs-version' => 'fake-bs-version',
          'trust-device-path' => 'fake-trust-device-path'
       }
@@ -83,7 +83,8 @@ describe 'cloud-provider-ini' do
     context 'optional properties' do
       let(:openstack_config) { required_openstack_config.merge optional_openstack_config }
       it 'renders the correct template for openstack' do
-        openstack_config.each { |k,v| expect(rendered_template).to include("#{k}=#{v}") }
+        openstack_config['ca-file'] = '/var/vcap/jobs/cloud-provider/config/openstack-ca.crt'
+        openstack_config.each { |k,v| expect(rendered_template).to include("#{k}=#{v}")}
       end
 
       context 'error handling' do

--- a/spec/openstack_ca_file_spec.rb
+++ b/spec/openstack_ca_file_spec.rb
@@ -1,0 +1,19 @@
+require 'rspec'
+
+describe 'openstack ca-file' do
+  let(:valid_cert) {"certificate"}
+  let(:rendered_template) do
+    properties = {
+        'cloud-provider' => {
+            'openstack' => {
+                'ca-file' => 'certificate'
+            }
+        }
+    }
+    compiled_template('cloud-provider', 'config/openstack-ca.crt', properties)
+  end
+
+  it 'renders a valid ca-file' do
+    expect(rendered_template.chomp).to eq(valid_cert)
+  end
+end


### PR DESCRIPTION
For openstack ca-file should be a file not a string.

This PR introduce a new file called openstack-ca.crt.erb which will be filled with the ca-file parameters from the cloud-provider spec.

If nothing is given the file will be empty and not added to the cloud-provider config.