### PR TITLE
More robusting detect script for pods

### DIFF
--- a/jobs/kubernetes-system-specs/spec
+++ b/jobs/kubernetes-system-specs/spec
@@ -39,6 +39,12 @@ properties:
     description: The admin password for the Kubernetes cluster
   api-token:
     description: The token to access Kubernetes API
+  wait-until-ready:
+    description: Max time to wait in sec until pods is ready.
+    default: 30
+  wait-until-ready-int:
+    description: Interval in sec. to check if a pod is ready
+    default: 2
   tls.kubernetes:
     description: "Certificate and private key for the Kubernetes master"
   tls.kubernetes-dashboard:

--- a/jobs/kubernetes-system-specs/templates/bin/deploy-specs.erb
+++ b/jobs/kubernetes-system-specs/templates/bin/deploy-specs.erb
@@ -11,9 +11,36 @@ apply_spec() {
   ${kubectl} apply -f "${spec_file}" || echo "Spec file already applied: ${1}"
 }
 
-wait_for() {
-    ${kubectl} rollout status "deployments/${1}" -w --namespace=kube-system
+wait_for(){
+  local period="<%= p('wait-until-ready') %>"
+  local interval="<%= p('wait-until-ready-int') %>"
+  local selector="${1}"
+
+  echo "Waiting for pods to be ready for ${period}s (interval: ${interval}s, selector: ${selector:-''})"
+  # Kubernetes template
+  local template='{{range .items}}{{if not .metadata.deletionTimestamp}}{{.metadata.name}}{{range .status.conditions}}{{if eq .type "Ready"}} {{.status}}{{end}}{{end}}{{"\n"}}{{end}}{{end}}'
+  local statuses not_ready ready
+
+  for ((i=0; i<$period; i+=$interval)); do
+    sleep "$interval"
+
+    statuses="$($kubectl  get po --namespace=kube-system --selector=$selector -o template --template="$template")"
+    not_ready="$(echo "$statuses" | grep -c "False" ||:)"
+    ready="$(echo "$statuses" | grep -c "True" ||:)"
+
+    echo "Waiting for pods to be ready... ($ready/$(($not_ready + $ready)))"
+
+    if [[ "$not_ready" -eq 0 ]]; then
+      return 0
+    fi
+  done
+
+  echo "Waited for ${period}s, but the following pods are not ready yet."
+  echo "$statuses" | awk '{if ($2 == "False") print "- " $1}'
+  return 1
+
 }
+
 
 create_dashboard_secrets() {
   local secret_name=kubernetes-dashboard-certs


### PR DESCRIPTION
This PR propose a more robust mechanics to detect if a pods is ready or not.

Until now  `kubo-release` was using the watch command from kubctl which do not allow to confifure timeout or so on.

I was gettings a lot of failed deployment due to the deployment script. With this code I didn't any failed one since.

@glestaris @BenChapman what do you think ?