### PR TITLE
Add default privileged class to api server

### DIFF
--- a/jobs/kube-apiserver/templates/bin/kube_apiserver_ctl.erb
+++ b/jobs/kube-apiserver/templates/bin/kube_apiserver_ctl.erb
@@ -61,7 +61,7 @@ start_kube_apiserver() {
 
   exec chpst -u vcap:vcap  \
     kube-apiserver \
-      --admission-control=DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount \
+      --admission-control=DefaultStorageClass,DenyEscalatingExec,LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount \
       --anonymous-auth=false \
       --allow-privileged=<%= p('allow_privileged') %> \
       --apiserver-count=<%= api_server_count %> \


### PR DESCRIPTION
This allows simplify our CI spec by removing storage class name and simplifies user flow.
See more:

https://v1-8.docs.kubernetes.io/docs/admin/admission-controllers/#defaultstorageclass