### PR TITLE
Remove golang blob

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -46,10 +46,6 @@ flannel-v0.9.1-linux-amd64.tar.gz:
   size: 9084492
   object_id: 0672c984-dd38-4db1-5efd-0515a0ace8ee
   sha: 9d92bf991341163a16a6b9c1a54d45466826a658
-go/go1.9.2.linux-amd64.tar.gz:
-  size: 104247844
-  object_id: 9dd1786f-8cda-4ce4-4a95-6fe98ed237d5
-  sha: 94c889e039e3d2e94ed95e8f8cb747c5bc1c2b58
 govc_v0.16.0_linux_amd64.gz:
   size: 7941649
   object_id: a1f90508-10d4-4f13-43b6-4974e47b29c3


### PR DESCRIPTION
- We don't need it because we're using vendor packages golang

[#154997642]