### PR TITLE
Add the BOSH instance ID to the node labels

### DIFF
--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -25,7 +25,7 @@ DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
 <% end %>
 
 <%
-  labels = ["spec.ip=#{spec.ip}"]
+  labels = ["spec.ip=#{spec.ip}","bosh.id=#{spec.id}"]
   labels += p("labels").map {|k,v| "#{k}=#{v}"}
   labels = labels.join(',')
 %>

--- a/spec/kubelet_ctl_spec.rb
+++ b/spec/kubelet_ctl_spec.rb
@@ -6,10 +6,18 @@ require 'fileutils'
 require 'open3'
 
 describe 'kubelet_ctl' do
-  let(:rendered_template) { compiled_template('kubelet', 'bin/kubelet_ctl', {}, {}, {}, 'z1') }
+  let(:rendered_template) { compiled_template('kubelet', 'bin/kubelet_ctl', {}, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id') }
 
   it 'labels the kubelet with its own az' do
     expect(rendered_template).to include(',failure-domain.beta.kubernetes.io/zone=z1')
+  end
+
+  it 'labels the kubelet with the spec ip' do
+    expect(rendered_template).to include('spec.ip=fake-bosh-ip')
+  end
+
+  it 'labels the kubelet with the bosh id' do
+    expect(rendered_template).to include(',bosh.id=fake-bosh-id')
   end
 
   it 'has no http proxy when no proxy is defined' do

--- a/spec/support/template_helpers.rb
+++ b/spec/support/template_helpers.rb
@@ -6,14 +6,15 @@ require 'yaml'
 module TemplateHelpers
   include Bosh::Template::PropertyHelper
 
-  def compiled_template(job_name, template_name, manifest_properties = {}, links = {}, network_properties = [], az = '', ip = '')
-    manifest = emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip)
+  def compiled_template(job_name, template_name, manifest_properties = {}, links = {}, network_properties = [], az = '', ip = '', id = '')
+    manifest = emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip, id)
+
     renderer = Bosh::Template::Renderer.new(context: manifest)
     renderer.render("jobs/#{job_name}/templates/#{template_name}.erb")
   end
 
   # Trying to emulate bosh director Bosh::Director::DeploymentPlan::Job#extract_template_properties
-  def emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip)
+  def emulate_bosh_director_merge(job_name, manifest_properties, links, network_properties, az, ip, id)
     job_spec = YAML.load_file("jobs/#{job_name}/spec")
     spec_properties = job_spec['properties']
 
@@ -46,7 +47,8 @@ module TemplateHelpers
       'networks' => network_properties,
       'links' => links,
       'az' => az,
-      'ip' => ip
+      'ip' => ip,
+      'id' => id,
     }.to_json
   end
 


### PR DESCRIPTION
This will allow the NSX-T NCP component to match the k8s node with the underlying VM when using the vSphere CPI with NSX-T enabled, as it also tags the VM with the same BOSH instance ID.