### PR TITLE
Remove stopping rpcbind

### DIFF
--- a/jobs/kubelet/templates/bin/pre-start.erb
+++ b/jobs/kubelet/templates/bin/pre-start.erb
@@ -2,8 +2,6 @@
 
 set -eu -o pipefail
 
-/etc/init.d/rpcbind stop || echo Already stopped.
-
 # Mark all mounted devices as shareable for MountPropagation feature
 # https://github.com/kubernetes/kubernetes/issues/61058
 while read -r line; do

--- a/spec/kubelet_pre_start_spec.rb
+++ b/spec/kubelet_pre_start_spec.rb
@@ -9,7 +9,6 @@ describe 'kubelet-pre-start-script' do
   let(:link_spec) { {} }
 
   it 'renders' do
-    expect(rendered_template).to include('rpcbind stop')
     expect(rendered_template).to_not include('GOVC')
   end
 


### PR DESCRIPTION
This line was added to support experimental support for `glusterfs` long-long time ago.
Glusterfs was starting rpcbind with its own settings.

Now stopping rpcbind prevents Kubernetes from using NFS.