### PR TITLE
Enables kube-controller-manager to issue certificates

### DIFF
--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -10,6 +10,8 @@ templates:
   config/openstack-ca.crt.erb: config/openstack-ca.crt
   config/service-account-private-key.pem.erb: config/service-account-private-key.pem
   config/service_key.json.erb: config/service_key.json
+  config/cluster-signing-ca.pem.erb: config/cluster-signing-ca.pem
+  config/cluster-signing-key.pem.erb: config/cluster-signing-key.pem
 
 packages:
 - kubernetes
@@ -18,6 +20,8 @@ packages:
 properties:
   api-token:
     description: "API Token for the system:kube-controller-manager user"
+  cluster-signing:
+    description: "CA Certificate and private key for the certificate controller to issue certificates"
   http_proxy:
     description: http_proxy env var for the kubernetes-controller-manager binary (i.e. for cloud provider interactions)
   https_proxy:

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -8,6 +8,8 @@ processes:
   - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
   <% end %>
   - --cluster-name=kubernetes
+  - --cluster-signing-cert-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-ca.pem
+  - --cluster-signing-key-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-key.pem
   - --kubeconfig=/var/vcap/jobs/kube-controller-manager/config/kubeconfig
   - --leader-elect
   - --root-ca-file=/var/vcap/jobs/kube-controller-manager/config/ca.pem

--- a/jobs/kube-controller-manager/templates/config/cluster-signing-ca.pem.erb
+++ b/jobs/kube-controller-manager/templates/config/cluster-signing-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('cluster-signing.certificate') %>

--- a/jobs/kube-controller-manager/templates/config/cluster-signing-key.pem.erb
+++ b/jobs/kube-controller-manager/templates/config/cluster-signing-key.pem.erb
@@ -1,0 +1,1 @@
+<%= p('cluster-signing.private_key') %>


### PR DESCRIPTION
This is a followup from https://github.com/cloudfoundry-incubator/kubo-release/pull/187 (GitHub wouldn't allow me to reopen the PR).

* this is required by the `webhook-create-signed-cert.sh` script
required to install istio sidecar

https://istio.io/docs/setup/kubernetes/sidecar-injection#installing-the-webhook


**Notes**
* Related PR: https://github.com/cloudfoundry-incubator/kubo-deployment/pull/281