### PR TITLE
Allow the operator to control admission plugins directly

### DIFF
--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -31,16 +31,6 @@ properties:
     description: The password for the admin account
   admission-plugins:
     description: Map of admission plugs and a boolean indicating whether it should be enabled or disabled. Anything not explicitly declared in the map reverts to the default Kubernetes behavior.A
-    default:
-      DefaultStorageClass: true
-      DenyEscalatingExec: true
-      LimitRanger: true
-      MutatingAdmissionWebhook: true
-      NamespaceExists: true
-      NamespaceLifecycle: true
-      ResourceQuota: true
-      SecurityContextDeny: true
-      ServiceAccount: true
   allow_privileged:
     description: Allow privileged containers
     default: false

--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -29,8 +29,20 @@ properties:
     description: The admin username for the Kubernetes cluster
   admin-password:
     description: The password for the admin account
+  admission-plugins:
+    description: Map of admission plugs and a boolean indicating whether it should be enabled or disabled. Anything not explicitly declared in the map reverts to the default Kubernetes behavior.A
+    default:
+      DefaultStorageClass: true
+      DenyEscalatingExec: true
+      LimitRanger: true
+      MutatingAdmissionWebhook: true
+      NamespaceExists: true
+      NamespaceLifecycle: true
+      ResourceQuota: true
+      SecurityContextDeny: true
+      ServiceAccount: true
   allow_privileged:
-    description: Allows privileged containers for the Kubernetes cluster
+    description: Allow privileged containers
     default: false
   anonymous_auth:
     description: |
@@ -42,9 +54,6 @@ properties:
   authorization-mode:
     description: The authorization mode for kube-apiserver. Should be 'abac' or 'rbac'
     default: rbac
-  deny_escalating_exec:
-    description: Enable the `DenyEscalatingExec` admission controller.
-    default: true
   enable_audit_logs:
     description: Enables audit logs
     default: true

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -11,8 +11,12 @@
 
   etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",")
 
-  enable_admission_plugins = p('admission-plugins').select { |k, v| v == true }.keys
-  disable_admission_plugins = p('admission-plugins').select { |k, v| v== false }.keys
+  enable_admission_plugins = []
+  disable_admission_plugins = []
+  if_p('admission-plugins') do |plugins|
+    enable_admission_plugins = p('admission-plugins').select { |k, v| v == true }.keys
+    disable_admission_plugins = p('admission-plugins').select { |k, v| v== false }.keys
+  end
 %>
 processes:
 - name: kube-apiserver

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -11,18 +11,8 @@
 
   etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",")
 
-  admission_control_options = [
-    "LimitRanger", "NamespaceExists",
-    "NamespaceLifecycle","ResourceQuota","ServiceAccount",
-    "DefaultStorageClass", "MutatingAdmissionWebhook"]
-
-  if p('deny_escalating_exec')
-    admission_control_options.push("DenyEscalatingExec")
-  end
-
-  if !p('allow_privileged')
-    admission_control_options.push("SecurityContextDeny")
-  end
+  enable_admission_plugins = p('admission-plugins').select { |k, v| v == true }.keys
+  disable_admission_plugins = p('admission-plugins').select { |k, v| v== false }.keys
 %>
 processes:
 - name: kube-apiserver
@@ -36,7 +26,12 @@ processes:
   - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
   - --cloud-config=/var/vcap/jobs/kube-apiserver/config/cloud-provider.ini
   <% end %>
-  - --enable-admission-plugins=<%= admission_control_options.join(",") %>
+  <% if not disable_admission_plugins.empty? %>
+  - --disable-admission-plugins=<%= disable_admission_plugins.join(",") %>
+  <% end %>
+  <% if not enable_admission_plugins.empty? %>
+  - --enable-admission-plugins=<%= enable_admission_plugins.join(",") %>
+  <% end %>
   - --enable-swagger-ui
   - --etcd-servers=<%= etcd_endpoints %>
   - --etcd-cafile=/var/vcap/jobs/kube-apiserver/config/etcd-ca.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it so that the operator can explicitly control the enabled and disabled admission plugins on `kube-apiserver`. Currently operators are limited in what admission controllers they can and cannot disable and so they cannot deploy according to their own needs.

The manifest will now explicitly consume a map of the format `<name>: <boolean>`. For example:

```
jobs:
  - name: kube-apiserver
    release: kubo
    properties:
      ...
      admission-plugins:
        DefaultStorageClass: true
        DenyEscalatingExec: true
        LimitRanger: true
        MutatingAdmissionWebhook: true
        NamespaceExists: true
        NamespaceLifecycle: true
        ResourceQuota: true
        SecurityContextDeny: true
        ServiceAccount: true
      ...
```

The list of valid admission plugins can be found in the [kube-apiserver documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). Note that any plugin _not_ explicitly listed will default to its Kubernetes-default behavior.

For full flexibility of controllers and APIs, https://github.com/cloudfoundry-incubator/kubo-release/pull/215 is also related. That PR makes the `--runtime-config` flag additionally flexible so that operators can enable the necessary APIs that support/are supported by a plugin (e.g. `PodPreset` -> `settings.k8s.io/v1alpha1`)

**How can this PR be verified?**
There are spec tests in this PR that verify the behavior of the map property.

**Is there any change in kubo-deployment?**
https://github.com/cloudfoundry-incubator/kubo-deployment/pull/310

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
https://github.com/cloudfoundry-incubator/kubo-deployment/issues/309
[#157758561](https://www.pivotaltracker.com/story/show/157758561)

**Release note**:

```release-note
Kubernetes Admission Control Plugins are now globally available to the BOSH operator.

The manifest will now explicitly consume a map of the format `<name>: <boolean>`. 
For example:

    ```
    jobs:
      - name: kube-apiserver
        release: kubo
        properties:
          ...
          admission-plugins:
            DefaultStorageClass: true
            DenyEscalatingExec: true
            LimitRanger: true
            MutatingAdmissionWebhook: true
            NamespaceExists: true
            NamespaceLifecycle: true
            ResourceQuota: true
            SecurityContextDeny: true
            ServiceAccount: true
          ...
    ```

```