### PR TITLE
Enable a configurable runtime-config on API server

### DIFF
--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -47,6 +47,10 @@ properties:
     default: true
   feature_gates:
     description: A map of key=value pairs that describe alpha or experimental features.
+  runtime_config:
+    description: |
+      A map of key-value pairs that describe runtime configuration that may be passed to apiserver.
+      See kube-apiserver documentation for details.
   http_proxy:
     description: http_proxy env var for the kubernetes-api binary (i.e. for cloud provider interactions)
   https_proxy:

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -31,6 +31,15 @@
   if_p('feature_gates') do |gates|
     feature_gates.merge!(gates)
   end
+
+  runtime_config = {
+    'api/v1' => true,
+    'rbac.authorization.k8s.io/v1alpha1' => true
+  }
+
+  if_p('runtime_config') do |config|
+    runtime_config.merge!(config)
+  end
 %>
 processes:
 - name: kube-apiserver
@@ -70,7 +79,7 @@ processes:
   - --enable-aggregator-routing
   - --v=<%=p('logging-level') %>
   - --authorization-mode=Node,RBAC
-  - --runtime-config=api/v1,rbac.authorization.k8s.io/v1alpha1
+  - --runtime-config=<%= runtime_config.flat_map {|k,v| "#{k}=#{v}"}.join(",") %>
   - --client-ca-file=/var/vcap/jobs/kube-apiserver/config/kubernetes-ca.pem
   - --proxy-client-cert-file=/var/vcap/jobs/kube-apiserver/config/kubernetes.pem
   - --proxy-client-key-file=/var/vcap/jobs/kube-apiserver/config/kubernetes-key.pem

--- a/spec/kube_apiserver_bpm_yml_spec.rb
+++ b/spec/kube_apiserver_bpm_yml_spec.rb
@@ -197,4 +197,20 @@ describe 'kube-apiserver' do
     bpm_yml = YAML.safe_load(rendered_kube_apiserver_bpm_yml)
     expect(bpm_yml['processes'][0]['args']).to include('--feature-gates=RotateKubeletServerCertificate=true,CustomFeature1=true,CustomFeature2=false')
   end
+
+  it 'sets runtime-config with custom apis if there are properties defined' do
+    rendered_kube_apiserver_bpm_yml = compiled_template(
+      'kube-apiserver',
+      'config/bpm.yml',
+      {
+        'runtime_config' => {
+          'custom.api/v1' => true,
+        }
+      },
+      link_spec
+    )
+
+    bpm_yml = YAML.safe_load(rendered_kube_apiserver_bpm_yml)
+    expect(bpm_yml['processes'][0]['args']).to include('--runtime-config=api/v1=true,rbac.authorization.k8s.io/v1alpha1=true,custom.api/v1=true')
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows the operator to explicitly enable or disable certain API versions or
specific resources. As an example, an operator could use this to enable
the [PodPreset API](https://kubernetes.io/docs/tasks/inject-data-application/podpreset/) (`settings.k8s.io/v1alpha1`).

The manifest will now explicitly consume a map of the format `<name>: <boolean>`. For example:

```
jobs:
  - name: kube-apiserver
    release: kubo
    properties:
      ...
      runtime-config
        settings.k8s.io/v1alpha1: true
      ...
```

**How can this PR be verified?**
There are spec tests in this PR that verify the behavior of the map property.

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
[#157931620](https://www.pivotaltracker.com/story/show/157931620)

**Release note**:

```release-note
`kube-apiserver`'s `--runtime-config` flag is now globally configurable by the BOSH operator.

The manifest will now explicitly consume a map of the format `<name>: <boolean>`. 
For example:

    ```
    jobs:
      - name: kube-apiserver
        release: kubo
        properties:
          ...
          runtime-config
            settings.k8s.io/v1alpha1: true
          ...
    ```
```




