### PR TITLE
Enable PodSecurityPolicy with privileged and unprivileged defaults

### DIFF
--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -114,6 +114,7 @@ provides:
 - name: kube-apiserver
   type: kube-apiserver
   properties:
+  - allow_privileged
   - admin-username
   - admin-password
   - tls.kubernetes.ca

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -22,10 +22,6 @@
     admission_control_options.push("DenyEscalatingExec")
   end
 
-  if !p('allow_privileged')
-    admission_control_options.push("SecurityContextDeny")
-  end
-
   feature_gates = {
     'RotateKubeletServerCertificate' => true
   }

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -14,7 +14,9 @@
   admission_control_options = [
     "LimitRanger", "NamespaceExists",
     "NamespaceLifecycle","ResourceQuota","ServiceAccount",
-    "DefaultStorageClass", "NodeRestriction", "MutatingAdmissionWebhook"]
+    "DefaultStorageClass", "NodeRestriction", "MutatingAdmissionWebhook",
+    "PodSecurityPolicy"
+  ]
 
   if p('deny_escalating_exec')
     admission_control_options.push("DenyEscalatingExec")

--- a/jobs/kubernetes-roles/spec
+++ b/jobs/kubernetes-roles/spec
@@ -12,6 +12,7 @@ templates:
   config/policies/kube_proxy.yml: config/policies/kube_proxy.yml
   config/policies/kubelet.yml: config/policies/kubelet.yml
   config/policies/kubelet_drain.yml: config/policies/kubelet_drain.yml
+  config/policies/podsecuritypolicy.yml: config/policies/podsecuritypolicy.yml
   config/policies/route_sync.yml: config/policies/route_sync.yml
   config/policies/vsphere_cloud_provider.yml.erb: config/policies/vsphere_cloud_provider.yml
 

--- a/jobs/kubernetes-roles/spec
+++ b/jobs/kubernetes-roles/spec
@@ -12,7 +12,7 @@ templates:
   config/policies/kube_proxy.yml: config/policies/kube_proxy.yml
   config/policies/kubelet.yml: config/policies/kubelet.yml
   config/policies/kubelet_drain.yml: config/policies/kubelet_drain.yml
-  config/policies/podsecuritypolicy.yml: config/policies/podsecuritypolicy.yml
+  config/policies/podsecuritypolicy.yml.erb: config/policies/podsecuritypolicy.yml
   config/policies/route_sync.yml: config/policies/route_sync.yml
   config/policies/vsphere_cloud_provider.yml.erb: config/policies/vsphere_cloud_provider.yml
 

--- a/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml
+++ b/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml
@@ -1,0 +1,63 @@
+---
+# The least restricted policy you can make, equivalent to not using the pod
+# security policy admission controller.
+#
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy#example-policies
+# https://github.com/kubernetes/website/blob/master/content/en/docs/concepts/policy/privileged-psp.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:privileged
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: psp:privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts

--- a/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml.erb
+++ b/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml.erb
@@ -11,6 +11,9 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
+  # Probably can default this to true since the API server and Kubelet flags
+  # will prevent privileged containers anyway. Leaving it as-is because the
+  # flags are deprecated and may be removed in the future.
   privileged: <%= link('kube-apiserver').p('allow_privileged') %>
   allowPrivilegeEscalation: true
   allowedCapabilities:
@@ -54,6 +57,61 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: psp:privileged
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:masters
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: unprivileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:unprivileged
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: psp:unprivileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:unprivileged
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml.erb
+++ b/jobs/kubernetes-roles/templates/config/policies/podsecuritypolicy.yml.erb
@@ -11,7 +11,7 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
-  privileged: true
+  privileged: <%= link('kube-apiserver').p('allow_privileged') %>
   allowPrivilegeEscalation: true
   allowedCapabilities:
   - '*'

--- a/spec/kube_apiserver_bpm_yml_spec.rb
+++ b/spec/kube_apiserver_bpm_yml_spec.rb
@@ -94,7 +94,8 @@ describe 'kube-apiserver' do
     expect(bpm_yml['processes'][0]['args']).to include(
       '--enable-admission-plugins=LimitRanger,' \
       'NamespaceExists,NamespaceLifecycle,ResourceQuota,' \
-      'ServiceAccount,DefaultStorageClass,NodeRestriction,MutatingAdmissionWebhook,DenyEscalatingExec'
+      'ServiceAccount,DefaultStorageClass,NodeRestriction,MutatingAdmissionWebhook,' \
+      'PodSecurityPolicy,DenyEscalatingExec'
     )
   end
 

--- a/spec/kube_apiserver_bpm_yml_spec.rb
+++ b/spec/kube_apiserver_bpm_yml_spec.rb
@@ -99,18 +99,6 @@ describe 'kube-apiserver' do
     )
   end
 
-  it 'denies security context when privileged containers are not enabled' do
-    rendered_kube_apiserver_bpm_yml = compiled_template(
-      'kube-apiserver',
-      'config/bpm.yml',
-      {},
-      link_spec
-    )
-
-    bpm_yml = YAML.safe_load(rendered_kube_apiserver_bpm_yml)
-    expect(bpm_yml['processes'][0]['args']).to include(match(/--enable-admission-plugins=.*,SecurityContextDeny/))
-  end
-
   it 'has no http proxy when no proxy is defined' do
     rendered_kube_apiserver_bpm_yml = compiled_template(
       'kube-apiserver',

--- a/spec/kubernetes_roles_spec.rb
+++ b/spec/kubernetes_roles_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+require 'yaml'
+
+describe 'kubernetes-roles' do
+  let(:link_disallow_privileged) do
+    {
+      'kube-apiserver' => {
+        'address' => 'fake.kube-api-address',
+        'instances' => [],
+        'properties' => {
+          'allow_privileged' => false
+        }
+      }
+    }
+  end
+
+  let(:link_allow_privileged) do
+    {
+      'kube-apiserver' => {
+        'address' => 'fake.kube-api-address',
+        'instances' => [],
+        'properties' => {
+          'allow_privileged' => true
+        }
+      }
+    }
+  end
+
+  it 'disallows privileged containers when allow_privileged is false' do
+    rendered_k8s_role_psp = compiled_template(
+      'kubernetes-roles',
+      'config/policies/podsecuritypolicy.yml',
+      {},
+      link_disallow_privileged)
+
+    psp = YAML.safe_load(rendered_k8s_role_psp)
+    expect(psp['spec']['privileged']).to equal(false)
+  end
+
+  it 'allows privileged containers escalation when allow_privileged is true' do
+    rendered_k8s_role_psp = compiled_template(
+      'kubernetes-roles',
+      'config/policies/podsecuritypolicy.yml',
+      {},
+      link_allow_privileged)
+
+    psp = YAML.safe_load(rendered_k8s_role_psp)
+    expect(psp['spec']['privileged']).to equal(true)
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
CFCR currently does not expose a mechanism by which a cluster operator can control the security policies set on their cluster. As an example, the operator may wish to prevent all but a small subset of users from deploying privileged containers. Under the current mechanism, `allow-privileged` is an all-or-nothing flag that applies to _all_ users and service accounts.

This PR enables the [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy) access controller, which allows the operator to apply more fine-grained controls over who can and cannot access certain security features. It also disables `SecurityContextDeny` as the two aren't meant to be used at the same time and it can be modeled through `PodSecurityPolicy`.

The default pod security policies only allows members of the group `system:masters` to deploy privileged containers (through `psp/privileged`). Members of the group `system:serviceaccounts` and `system:authenticated` (that is, service accounts and authenticated users) are granted otherwise wholly-permissive privileges, but _are not_ allowed to deploy privileged containers. The constructs can
be found in the following:

* `PodSecurityPolicy`: `privileged` (`psp/privileged`) and `unprivileged` (`psp/unprivileged`)
* `ClusterRole`: `psp:privileged` (`clusterrole/psp:privileged`) and `psp:unprivileged` (`clusterrole/psp:unprivileged`)
* `ClusterRoleBinding`: `psp:privileged` (`clusterrolebinding/psp:privileged`) and `psp:unprivileged` (`clusterrolebinding/psp:unprivileged`)

Theoretically, these policies should be applied as part of a pre-upgrade hook, else service accounts and non-`cluster-admin` users will be unable to deploy pods in the period of time between the apiserver starting with the admission controller and the policies being made. Normally this period of time will be quite small and Kubernetes won't tear down any existing workloads, but if a `replicaset` is attempting to restore a pod, or something gets deployed during the upgrade, it will be unable to
start a pod until the policy is applied.

**How can this PR be verified?**
[The PodSecurityPolicy doc provides a good example](https://kubernetes.io/docs/concepts/policy/pod-security-policy#example). Running through the example to make sure that PSPs behave as-expected would require that the `ClusterRoleBinding` `psp:privileged` is deleted first. Once done, the example can be run through

To test that the `cluster-admin` can use the `PodSecurityPolicies` that we create by default, we can run these commands:

```
$ kubectl auth can-i use podsecuritypolicy/privileged
yes
$ kubectl auth can-i use podsecuritypolicy/unprivileged
yes
```

To test the privileges granted to a service account we can us these commands:

```
$ kubectl --as=system:serviceaccounts:kube-dns auth can-i use podsecuritypolicy/privileged
yes
$ kubectl --as=system:serviceaccounts:kube-dns auth can-i use podsecuritypolicy/unprivileged
no
```

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No. The tests are all leveraging `kubectl` with the `cluster-admin` credentials.  It's possible that a test which performs the above `kubectl auth can-i` commands could be added.

**Does this affect upgrade, or is there any migration required?**
`SecurityContextDeny` has been removed, so anyone relying on it will need to model the same behavior in a `PodSecurityPolicy`. `psp/unprivileged` is more-permissive than `SecurityContextDeny`, so there should be no effect on running workloads.

The policy _should_ be applied before upgrade to prevent any potential downtime when it comes to deploying additional pods. Until the policy gets applied, pods will not be able to be scheduled. This period of time should be quite short as it's only between the time when the first `kube-apiserver` starts up and when `kubernetes-roles` gets run.

**Which issue(s) this PR fixes:**
[#155793102](https://www.pivotaltracker.com/story/show/155793102)

**Release note**:

```release-note
`SecurityContextDeny` is no longer enabled when privileged containers are disabled.
Instead, it has been replaced with `PodSecurityPolicy` that is always enabled and has
a default policy that is as permissive as possible. Cluster operators should build a more
strict set of policies that better secure their cluster in production.
```