### PR TITLE
Support configuring service cluster ip and pod network

### DIFF
--- a/jobs/apply-specs/spec
+++ b/jobs/apply-specs/spec
@@ -26,6 +26,9 @@ properties:
     description: The admin username for the Kubernetes cluster
   admin-password:
     description: The admin password for the Kubernetes cluster
+  kubedns-service-ip:
+    description: The service cluster IP for kube-dns, must reside within service-cluster-cidr set for kube-apiserver
+    default: "10.100.200.10"
   timeout-sec:
     description: Timeout for system spec deployment
     default: 1200

--- a/jobs/apply-specs/templates/specs/kube-dns.yml.erb
+++ b/jobs/apply-specs/templates/specs/kube-dns.yml.erb
@@ -25,7 +25,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: 10.100.200.10
+  clusterIP: <%= kubedns-service-ip %>
   ports:
   - name: dns
     port: 53

--- a/jobs/flanneld/spec
+++ b/jobs/flanneld/spec
@@ -13,7 +13,10 @@ packages:
 - flanneld
 - cni
 
-properties: {}
+properties:
+  pod-network-cidr:
+    description: The pod networking cidr for pod network overlay
+    default: "10.200.0.0/16"
 
 consumes:
 - name: etcd

--- a/jobs/flanneld/templates/bin/flanneld_ctl.erb
+++ b/jobs/flanneld/templates/bin/flanneld_ctl.erb
@@ -51,7 +51,7 @@ start_flanneld() {
     --cert-file /var/vcap/jobs/flanneld/config/etcd-client.crt \
     --key-file /var/vcap/jobs/flanneld/config/etcd-client.key \
     --ca-file /var/vcap/jobs/flanneld/config/etcd-ca.crt \
-    set /coreos.com/network/config '{"Network":"10.200.0.0/16","Backend":{"Type":"vxlan"}}'
+    set /coreos.com/network/config '{"Network":"<%= pod-network-cidr %>","Backend":{"Type":"vxlan"}}'
 
   flanneld -etcd-endpoints=<%= etcd_endpoints %> \
     --ip-masq \

--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -68,6 +68,9 @@ properties:
     default: 1235
   route-sync-password:
     description: The password for the route-sync user
+  service-cluster-cidr:
+    description: The service cluster IP cidr for hosting cluster services
+    default: "10.100.200.0/24"
   tls.kubernetes.ca:
     description: "CA Certificate for the Kubernetes master"
   tls.kubernetes.certificate:

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -61,7 +61,7 @@ processes:
   - --secure-port=8443
   - --service-account-key-file=/var/vcap/jobs/kube-apiserver/config/service-account-public-key.pem
   - --service-account-lookup
-  - --service-cluster-ip-range=10.100.200.0/24
+  - --service-cluster-ip-range=<%= service-cluster-cidr %>
   - --service-node-port-range=30000-32767
   - --tls-cert-file=/var/vcap/jobs/kube-apiserver/config/kubernetes.pem
   - --tls-private-key-file=/var/vcap/jobs/kube-apiserver/config/kubernetes-key.pem

--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -28,6 +28,9 @@ properties:
     description: https_proxy env var for the kubernetes-controller-manager binary (i.e. for cloud provider interactions)
   no_proxy:
     description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
+  service-cluster-cidr:
+    description: The service cluster IP for hosting cluster services
+    default: "10.100.200.0/24"
   tls.kubo-ca:
     description: "Certificate and private key for the Kubo CA"
   service-account-private-key:

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -15,7 +15,7 @@ processes:
   - --leader-elect
   - --root-ca-file=/var/vcap/jobs/kube-controller-manager/config/ca.pem
   - --service-account-private-key-file=/var/vcap/jobs/kube-controller-manager/config/service-account-private-key.pem
-  - --service-cluster-ip-range=10.100.200.0/24
+  - --service-cluster-ip-range=<%= service-cluster-cidr %>
   - --terminated-pod-gc-threshold=100
   - --use-service-account-credentials
   - --v=<%=p('logging-level') %>

--- a/jobs/kube-proxy/spec
+++ b/jobs/kube-proxy/spec
@@ -22,3 +22,6 @@ properties:
   logging-level:
     description: "V-leveled logging at the specified level. See https://github.com/golang/glog"
     default: 2
+  pod-network-cidr:
+    description: The pod networking cidr for pod network overlay
+    default: "10.200.0.0/16"

--- a/jobs/kube-proxy/templates/config/config.yml.erb
+++ b/jobs/kube-proxy/templates/config/config.yml.erb
@@ -6,7 +6,7 @@ clientConnection:
   contentType: application/vnd.kubernetes.protobuf
   kubeconfig: /var/vcap/jobs/kube-proxy/config/kubeconfig
   qps: 5
-clusterCIDR: 10.200.0.0/16
+clusterCIDR: <%= pod-network-cidr %>
 configSyncPeriod: 15m0s
 conntrack:
   max: 0

--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -65,6 +65,9 @@ properties:
   logging-level:
     description: "V-leveled logging at the specified level. See https://github.com/golang/glog"
     default: 2
+  kubedns-service-ip:
+    description: The service IP for kube-dns, must match what is configured for kube-dns
+    default: "10.100.200.10"
 
 consumes:
 - name: cloud-provider

--- a/jobs/kubelet/templates/config/kubeletconfig.yml.erb
+++ b/jobs/kubelet/templates/config/kubeletconfig.yml.erb
@@ -8,7 +8,7 @@ authentication:
 authorization:
   mode: Webhook
 clusterDNS: 
-  - 10.100.200.10
+  - <%= kubedns-service-ip %>
 clusterDomain: cluster.local
 failSwapOn: false
 readOnlyPort: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow cluster creators to set/modify kubernetes service and pod networks by modifying their CIDR. Additionally this will allow a user to change the kubedns service IP so it can also reside within a changed network range. The existing values are set as safe defaults

**How can this PR be verified?**
Build a cluster and verify IPs

**Is there any change in kubo-deployment?**
kubo-deployment shouldnt need a change since all modifications have defaults. however in order to take advantage of the ability to change, kubo-deployment will need updating.

**Is there any change in kubo-ci?**
no

**Does this affect upgrade, or is there any migration required?**
If users change the networks for an existing cluster, it may cause some confustion, but everything should come back up- this will require they apply-specs for kube-dns pods to get updated as well.

**Which issue(s) this PR fixes:**
This does not have an open github issue, however there should be an existing internal issue tracker for this somewhere.

**Release note**:
```release-note
Now supports the modification of both kubernetes pod network and service network by overriding the appropriate CIDRs.
```
