### PR TITLE
Allow an operator to configure which addons get bootstrapped to a CFCR

### DIFF
--- a/jobs/apply-specs/spec
+++ b/jobs/apply-specs/spec
@@ -39,6 +39,9 @@ properties:
     description: "Certificate and private key for Heapster"
   tls.influxdb:
     description: "Certificate and private key for InfluxDB"
+  addons:
+    description: A List of default add-ons bootstrapped in the Kubernetes cluster
+    default: ["heapster", "influxdb", "dashboard"]
   addons-spec:
     description: Spec of the addons to be deployed into the Kubernetes cluster
     default: ""

--- a/jobs/apply-specs/templates/bin/deploy-specs.erb
+++ b/jobs/apply-specs/templates/bin/deploy-specs.erb
@@ -61,20 +61,37 @@ create_dashboard_secrets() {
 }
 
 main() {
+
+<%
+  supported_addons = ['heapster', 'influxdb', 'dashboard']
+
+  bootstrap_addons = p('addons')
+
+  bootstrap_addons = bootstrap_addons.map do |v|
+      supported_addons.include?(v) or
+        raise "#{v} is a not supported addon"
+end %>
+
   apply_spec "kube-dns.yml"
   wait_for kube-dns
 
-  create_heapster_secrets
-  apply_spec "heapster.yml"
-  wait_for heapster
+  <% if initial_addons.include?('heapster') %>
+    create_heapster_secrets
+    apply_spec "heapster.yml"
+    wait_for heapster
+  <% end %>
 
-  create_influx_secrets
-  apply_spec "influxdb.yml"
-  wait_for monitoring-influxdb
+  <% if initial_addons.include?('influxdb') %>
+    create_influx_secrets
+    apply_spec "influxdb.yml"
+    wait_for monitoring-influxdb
+  <% end %>
 
-  create_dashboard_secrets
-  apply_spec "kubernetes-dashboard.yml"
-  wait_for kubernetes-dashboard
+  <% if initial_addons.include?('dashboard') %>
+    create_dashboard_secrets
+    apply_spec "kubernetes-dashboard.yml"
+    wait_for kubernetes-dashboard
+  <% end %>
 
   <% if_link('cloud-provider') do |cloud_provider| %>
     <% cloud_provider.if_p('cloud-provider.type') do |p| %>


### PR DESCRIPTION
**What this PR does / why we need it**:
+ This PR allows an operator to chose which addons get applied to a CFCR cluster. This modifies the `apply-specs` errand behaviour.

+ Today GKE allows a [toggle behaviour](https://cloud.google.com/sdk/gcloud/reference/container/clusters/update) on addons applied in a cluster using the `--update-addons` flag

+ An operator may not want to use the default addons. For example [GKE does not recommend using the Dashboard](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster). 

**How can this PR be verified?**
+ This does not change the behaviour of CFCR clusters today, so as long as current tests pass. Nothing should be different.

+ I have chosen to keep `kube-dns` as a default always applied add-on because it is required for the cluster to work. I do not think the others are required. 

**Is there any change in kubo-deployment?**
N/A

**Is there any change in kubo-ci?**
N/A

**Does this affect upgrade, or is there any migration required?**
+ I do not think this will affect upgrades. 
+ This will **not** remove an add-on from a cluster if it is removed from the `apply-specs` job.
+ There may be behaviour I have not thought of during an upgrade, if the jobs spec changes and `apply-specs` is run

**Which issue(s) this PR fixes:**

**Release note**:
```release-note
An operator can now chose which system addons get applied to their cluster after creation.
```

