### PR TITLE
Quote vsphere user in cloud-provider config file

### DIFF
--- a/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
+++ b/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
@@ -17,7 +17,7 @@
         cloud_provider.if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag  }
         cloud_config['multizone'] = true
       elsif provider_type == 'vsphere' && spec['name'].include?("master")
-        cloud_config['user'] = cloud_provider.p('cloud-provider.vsphere.user').gsub('\\','\\\\\\')
+        cloud_config['user'] = '"' + cloud_provider.p('cloud-provider.vsphere.user').gsub('\\','\\\\\\') + '"'
 
         password = ""
         cloud_provider.p('cloud-provider.vsphere.password').split("").each do |i|

--- a/spec/cloud_provider_ini_spec.rb
+++ b/spec/cloud_provider_ini_spec.rb
@@ -72,11 +72,20 @@ describe 'cloud-provider-ini' do
 
     it 'renders the correct template for vsphere' do
       vsphere_config.each do |k, v|
-        if k == 'password'
+        if %w[password user].include? k
           expect(rendered_template).to include("#{k}=\"#{v}\"")
         else
           expect(rendered_template).to include("#{k}=#{v}")
         end
+      end
+    end
+
+    context 'user in the form domain\user' do
+      it 'has a double backslash in the template' do
+        vsphere_config['user'] = 'domain\fake-user'
+        # In the following case \\\\ appears as \\ in the actual config
+        # this is because we cannot do a string with an unescaped \ in Ruby
+        expect(rendered_template).to include('user="domain\\\\fake-user"')
       end
     end
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows users to specify NTLM-formatted usernames for VSphere.

Previously, when you tried to provide a NTLM-formatted username the kube-cloud-controller manager would produce the following error:

```
14:26:12.175060       1 controllermanager.go:159] error building controller context: cloud provider could not be initialized: could not init cloud provider "vsphere": 3:6: unquoted '\' must be followed by new line
```

**How can this PR be verified?**
This can be verified by using a NTLM-formatted username as a parameter in the manifest. Here is an example ops-file:

```
- type: replace
  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/vsphere/user?
  value: "vsphere.local\example-user"
```

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**
n/a