### PR TITLE
Enable hostPort feature in CFCR

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,3 @@
-cni/cni-amd64-v0.5.2.tgz:
-  size: 14085755
-  object_id: 31cb39af-c33d-4df8-4d45-c02541806e39
-  sha: 71f411080245aa14d0cc06f6824e8039607dd9e9
 cni/cni-plugins-amd64-v0.7.1.tgz:
   size: 17108856
   object_id: 50dc58eb-107d-483a-4e37-5a243ffed520

--- a/jobs/flanneld/templates/bin/flanneld_ctl.erb
+++ b/jobs/flanneld/templates/bin/flanneld_ctl.erb
@@ -44,7 +44,28 @@ start_flanneld() {
   mknod /dev/net/tun c 10 200 || true
   echo 1 > /proc/sys/net/ipv4/ip_forward
   mkdir -p /etc/cni/net.d
-  echo '{"name":"flannel-network","type":"flannel","delegate":{"isDefaultGateway": true}}' > /etc/cni/net.d/10-flannel.conf
+  rm  /etc/cni/net.d/10-flannel.conf || true
+  cat  > /etc/cni/net.d/50-flannel.conflist <<EOL
+{
+    "name": "flannel-network",
+    "plugins": [
+	    {
+		    "type": "flannel",
+		    "delegate": {
+			    "hairpinMode": true,
+			    "isDefaultGateway": true
+		    }
+	    },
+	    {
+		    "type": "portmap",
+		    "capabilities": {
+			    "portMappings": true
+		    }
+	    }
+    ]
+}
+EOL
+
 
   /var/vcap/packages/etcdctl/etcdctl \
     --endpoints <%= etcd_endpoints %> \

--- a/packages/cni/packaging
+++ b/packages/cni/packaging
@@ -1,7 +1,7 @@
 set -exu
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar -xzf cni/cni-amd64*.tgz -C ${BOSH_INSTALL_TARGET}/bin/
+tar -xzf cni/cni-plugins-amd64*.tgz -C ${BOSH_INSTALL_TARGET}/bin/
 
 mkdir -p utillocal
 dpkg -x cni/util-linux*.deb utillocal/

--- a/packages/cni/spec
+++ b/packages/cni/spec
@@ -2,4 +2,5 @@
 name: cni
 
 files:
-- cni/*
+- cni/cni-plugins-amd64-v0.7.1.tgz
+- cni/util-linux_2.27.1-6ubuntu3_amd64.deb


### PR DESCRIPTION
Enables hostPort access

> The hostPort setting applies to the Kubernetes containers. The container port will be exposed to the external network at <hostIP>:<hostPort>, where the hostIP is the IP address of the Kubernetes node where the container is running and the hostPort is the port requested by the user. 

In order to support the hostport we need

- to have the latest [CNI binaries](https://github.com/containernetworking/cni)
- to have a chained cni [config](https://github.com/coreos/flannel/blob/8a083a890a4820fe97fa315dc1ecaa739c1d14db/Documentation/kube-flannel.yml#L55-L73)

This PR requires that we upload a new blob 

```
bosh add-blob ~/Downloads/cni-plugins-amd64-v0.7.1.tgz cni/cni-plugins-amd64-v0.7.1.tgz
bosh upload-blobs
```

**What this PR does / why we need it**:
This PR enables in CFCR the ability of user to apply specs that have hostPort, use now can apply the following

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-hostport
spec:
  containers:
  - image: nginx:1.13-alpine
    imagePullPolicy: Never
    name: nginx
    ports:
    - containerPort: 80
      hostPort: 40801
  restartPolicy: Always
```

**How can this PR be verified?**
Either by inspecting the iptables rules of the worker where the pod lives
 (`iptables -nvL -t nat |grep 40801`)
or simply by `curl <worker-ip>:40801`

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
There should be a test since kubo-ci has the tests

**Does this affect upgrade, or is there any migration required?**
It should not affect  the upgrade process, nevertheless it would be clean if it comes with a `recreation` of the stemcell (e.g. to clean some old iptables rules)