### PR TITLE
Make `cluster-name` argument from kube-controller-manager daemon a job property

### DIFF
--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -31,6 +31,9 @@ properties:
     description: "The duration that specifies how long the autoscaler has to wait before another upscale operation"
   horizontal-pod-autoscaler.use-rest-clients:
     description: "If true, horizontal pod autoscaler controller will use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy"
+  cluster-name:
+    description: Kubernetes cluster name
+    default: kubernetes
   http_proxy:
     description: http_proxy env var for the kubernetes-controller-manager binary (i.e. for cloud provider interactions)
   https_proxy:

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -7,7 +7,7 @@ processes:
   - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
   - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
   <%- end -%>
-  - --cluster-name=kubernetes
+  - --cluster-name=<%=p('cluster-name') %>
   - --cluster-signing-cert-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-ca.pem
   - --cluster-signing-key-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-key.pem
   <%- if_p('horizontal-pod-autoscaler.downscale-delay') do |delay| -%>


### PR DESCRIPTION
**What this PR does / why we need it**:
The use can now set the `cluster-name` argument from kube-controller-manager

**Why is this PR important? What is the user impact?**
The cluster-name value is by the kube-controller-manager for several things.
For example, in Azure, it uses as name of the Load Balancer.

**How can this PR be verified?**
Add a property in the deployment manifest file

**Is there any change in kubo-deployment?**
No, the default values is set to `kubernetes` which was the value hardcoded

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**
Non

**Release note**:
<!--
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Make `cluster-name` argument from kube-controller-manager daemon a job property
```
