### PR TITLE
Antifeature/remove possibility to set static creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ A [BOSH](http://bosh.io/) release for [Kubernetes](http://kubernetes.io).  Forme
 
 ## Prerequisites
 - A BOSH Director configured with UAA, Credhub, and BOSH DNS. We recommend using [BOSH Bootloader](https://github.com/cloudfoundry/bosh-bootloader) for this.
-- [kubo-release](https://github.com/cloudfoundry-incubator/kubo-release)
-- [kubo-deployment](https://github.com/cloudfoundry-incubator/kubo-deployment)
+- [Latest kubo-deployment tarball](https://github.com/cloudfoundry-incubator/kubo-deployment/releases/latest)
 - Accessing the master:
   - **Single Master:** Set up a DNS name pointing to your master's IP address
   - **Multiple Masters:** A TCP load balancer for your master nodes.
@@ -26,10 +25,8 @@ Kubernetes uses etcd as its datastore. The official infrastructure requirements 
 ## Deploying CFCR
 
 1. Upload the [latest Xenial stemcell](https://bosh.io/stemcells/#ubuntu-xenial) to the director.
-1. Upload the latest kubo-release to the director.
-    ```
-    bosh upload-release https://bosh.io/d/github.com/cloudfoundry-incubator/kubo-release
-    ```
+
+1. Untar the kubo-deployment tarball and rename it `kubo-deployment`
 
 1. Deploy
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ A [BOSH](http://bosh.io/) release for [Kubernetes](http://kubernetes.io).  Forme
 - Cloud Config with
   - `vm_types` named `minimal`, `small`, and `small-highmem` (See [cf-deployment](https://github.com/cloudfoundry/cf-deployment) for reference)
   - `network` named `default`
-  - There are three availability zones `azs`, and they are named `z1`,`z2`,`z3`
-  - Note: the cloud-config properties can be customized by applying ops-files. See `manifests/ops-files` for some examples
-  - If using loadbalancers then apply this `vm_extension` called `cfcr-master-loadbalancer` to the cloud-config to add the instances to your loadbalancers. See [BOSH documentation](https://bosh.io/docs/cloud-config/#vm-extensions) for information on how to configure loadbalancers.
+  - three availability zones `azs` named `z1`,`z2`,`z3`
+
+  Note: the cloud-config properties can be customized by applying ops-files. See `manifests/ops-files` for some examples.
+  
+  If using loadbalancers then apply the `vm_extension` called `cfcr-master-loadbalancer` to the cloud-config to add the instances to your loadbalancers. See [BOSH documentation](https://bosh.io/docs/cloud-config/#vm-extensions) for information on how to configure loadbalancers.
 
 #### Hardware Requirements
 Kubernetes uses etcd as its datastore. The official infrastructure requirements and example configurations for the etcd cluster can be found [here](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware.md).

--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -9,12 +9,9 @@ provides:
   type: cloud-provider
   properties:
   - cloud-provider.type
-  - cloud-provider.aws.access_key_id
-  - cloud-provider.aws.secret_access_key
   - cloud-provider.gce.network-name
   - cloud-provider.gce.subnetwork-name
   - cloud-provider.gce.project-id
-  - cloud-provider.gce.service_key
   - cloud-provider.gce.worker-node-tag
   - cloud-provider.openstack.auth-url
   - cloud-provider.openstack.bs-version
@@ -46,12 +43,6 @@ properties:
     description: "Type of Cloud Provider to use"
     example: gce, vsphere, openstack
 
-  # AWS specific properties
-  cloud-provider.aws.access_key_id:
-    description: AWS access key ID that is used by cloud-provider.
-  cloud-provider.aws.secret_access_key:
-    description: AWS secret access key that is used by cloud-provider.
-
   # GCE specific properties
   cloud-provider.gce.project-id:
     description: Google Cloud project id. Required when cloud-provider.type is gce.
@@ -61,8 +52,6 @@ properties:
     description: Google Cloud subnet name. Optional, used for internal load balancers.
   cloud-provider.gce.worker-node-tag:
     description: Google Cloud tag that identifies only worker nodes in this deployment.
-  cloud-provider.gce.service_key:
-    description: Google Cloud service key that is used by cloud-provider.
 
   # vSphere specific properties
   cloud-provider.vsphere.user:

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -111,14 +111,3 @@ processes:
     HTTP_PROXY: <%= http_proxy %>
     http_proxy: <%= http_proxy %>
     <% end %>
-    <% if_link('cloud-provider') do |cloud_provider| %>
-    <% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| %>
-    GOOGLE_APPLICATION_CREDENTIALS: /var/vcap/jobs/kube-apiserver/config/service_key.json
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.access_key_id') do |access_key_id| %>
-    AWS_ACCESS_KEY_ID: <%= access_key_id %>
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.secret_access_key') do |secret_access_key| %>
-    AWS_SECRET_ACCESS_KEY: <%= secret_access_key %>
-    <% end %>
-    <% end %>

--- a/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
+++ b/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
@@ -14,7 +14,6 @@
         cloud_config['project-id'] = cloud_provider.p('cloud-provider.gce.project-id')
         cloud_config['network-name'] = cloud_provider.p('cloud-provider.gce.network-name')
         cloud_provider.if_p('cloud-provider.gce.subnetwork-name') { |path| cloud_config['subnetwork-name'] = path }
-        cloud_provider.if_p('cloud-provider.gce.service_key') { cloud_config['token-url'] = 'nil' }
         cloud_provider.if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag  }
         cloud_config['multizone'] = true
       elsif provider_type == 'vsphere' && spec['name'].include?("master")

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -47,14 +47,3 @@ processes:
     HTTP_PROXY: <%= http_proxy %>
     http_proxy: <%= http_proxy %>
     <% end %>
-    <% if_link('cloud-provider') do |cloud_provider| %>
-    <% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| %>
-    GOOGLE_APPLICATION_CREDENTIALS: /var/vcap/jobs/kube-controller-manager/config/service_key.json
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.access_key_id') do |access_key_id| %>
-    AWS_ACCESS_KEY_ID: <%= access_key_id %>
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.secret_access_key') do |secret_access_key| %>
-    AWS_SECRET_ACCESS_KEY: <%= secret_access_key %>
-    <% end %>
-    <% end %>

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -18,15 +18,6 @@ DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
 
 <% if_link('cloud-provider') do |cloud_provider| %>
     cloud_config="/var/vcap/jobs/kubelet/config/cloud-provider.ini"
-    <% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| %>
-      export GOOGLE_APPLICATION_CREDENTIALS="/var/vcap/jobs/kubelet/config/service_key.json"
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.access_key_id') do |access_key_id| %>
-    export AWS_ACCESS_KEY_ID="<%= access_key_id %>"
-    <% end %>
-    <% cloud_provider.if_p('cloud-provider.aws.secret_access_key') do |secret_access_key| %>
-    export AWS_SECRET_ACCESS_KEY="<%= secret_access_key %>"
-    <% end %>
 <% end %>
 
 <%

--- a/spec/cloud_provider_ini_spec.rb
+++ b/spec/cloud_provider_ini_spec.rb
@@ -20,7 +20,7 @@ describe 'cloud-provider-ini' do
 
   context 'if cloud provider is gce' do
     let(:properties) { { 'cloud-provider' => { 'type' => 'gce', 'gce' => gce_config } } }
-    let(:gce_config) { { 'project-id' => 'fake-project-id', 'network-name' => 'fake-network-name', 'service_key' => 'foo', 'worker-node-tag' => 'fake-worker-node-tag' } }
+    let(:gce_config) { { 'project-id' => 'fake-project-id', 'network-name' => 'fake-network-name', 'worker-node-tag' => 'fake-worker-node-tag' } }
 
     it 'renders the correct template for gce' do
       expect(rendered_template).to include('project-id=fake-project-id')
@@ -30,18 +30,6 @@ describe 'cloud-provider-ini' do
 
     it 'defines the multi-az property' do
       expect(rendered_template).to include('multizone=true')
-    end
-
-    it 'sets token-url to nil if service_key is set' do
-      expect(rendered_template).to include('token-url=nil')
-    end
-
-    context 'if gce service key not defined' do
-      let(:gce_config) { { 'project-id' => 'fake-project-id', 'network-name' => 'fake-network-name', 'worker-node-tag' => 'fake-worker-node-tag' } }
-
-      it 'does not set token-url to nil' do
-        expect(rendered_template).not_to include('token-url=nil')
-      end
     end
 
     context 'if subnetwork-name is provider' do


### PR DESCRIPTION
**What this PR does / why we need it**:
 Remove the possibility to store credentials on the disk.
It was insecure.

**How can this PR be verified?**
Try to deploy with credentials, but without setting the vm_extensions

**Is there any change in kubo-deployment?**
Yes.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
If someone has been using credentials, they have to migrate to use VM Service Account in GCP or Instance Profile in AWS 

**Release note**:
```release-note
- Removed ability to set static credentials for GCP and AWS instead of using vm Service Account or Instance Profile
```
