### PR TITLE
Kube Proxy Azure hostname override fix

### DIFF
--- a/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
+++ b/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
@@ -32,6 +32,9 @@ get_hostname_override() {
   if [[ "gce" == "$cloud_provider" ]]; then
     # The hostname needs to be set to the instance name so the gce cloud provider can manage the instance
     hostname_override=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google")
+  elif [[ "azure" == "$cloud_provider" ]]; then
+    # K8s Azure provider assumes  the hostname == nodename and is required to resolve the VM instance ID
+    hostname_override=
   else
     hostname_override=<%= spec.ip %>
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:

For Azure support, Kube-Proxy needs to ensure it also gets the appropriate hostname (same as Kubelet), Local traffic IP masquerade (SNAT) will otherwise break, leading to undesired behavior.

**How can this PR be verified?**

Run through the examples here: https://kubernetes.io/docs/tutorials/services/source-ip/

You'll observe that with **externalTrafficPolicy=Local** , the curls will succeed.  Prior to this patch, they will not.

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
This might be a useful regression test case to capture in kubo-ci.

**Does this affect upgrade, or is there any migration required?**
No major impact.

**Which issue(s) this PR fixes:**

**Release note**:

Fixes an issue on Azure where Kube-Proxy won't properly SNAT `NodePort`, `Ingress` or `LoadBalancer` services, when `service.spec.externalTrafficPolicy` is set to `Local`.