### PR TITLE
Introduce CIFS utils for Windows file share volumes

### DIFF
--- a/jobs/cifs-utils/spec
+++ b/jobs/cifs-utils/spec
@@ -1,0 +1,10 @@
+---
+name: cifs-utils
+
+templates:
+  bin/pre-start.erb: bin/pre-start
+
+packages:
+- cifs-utils
+
+properties: {}

--- a/jobs/cifs-utils/templates/bin/pre-start.erb
+++ b/jobs/cifs-utils/templates/bin/pre-start.erb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e -x
+
+echo "Installing mount.cifs"
+pushd /var/vcap/packages/cifs-utils/
+  cp mount.cifs /sbin/
+popd
+
+echo "Installed mount.cifs"
+exit 0

--- a/packages/cifs-utils/packaging
+++ b/packages/cifs-utils/packaging
@@ -1,0 +1,54 @@
+set -e
+
+temp_path=${PWD}/temp
+mkdir $temp_path
+
+tar xf autoconf-2.69.tar.gz
+
+pushd autoconf-2.69
+  ./configure --prefix=${temp_path}
+  make
+  make install
+  export PATH=${PATH}:${temp_path}/bin
+popd
+
+tar xf automake-1.15.tar.gz
+
+pushd automake-1.15
+  ./configure --prefix=${temp_path}
+  make
+  make install
+popd
+
+tar xf libtool-2.4.6.tar.gz
+
+pushd libtool-2.4.6
+  ./configure --prefix=${temp_path}
+  make
+  make install
+popd
+
+tar xf talloc-2.1.9.tar.gz
+
+pushd talloc-2.1.9
+  ./configure --prefix=${temp_path}
+  make
+  make install
+popd
+
+tar xf pkg-config-0.29.2.tar.gz
+
+pushd pkg-config-0.29.2
+  ./configure --prefix=${temp_path} --with-internal-glib
+  make
+  make install
+popd
+
+tar jxf cifs-utils-6.7.tar.bz2
+
+pushd cifs-utils-6.7
+  autoreconf -i
+  ./configure --prefix=${temp_path}
+  make CPPFLAGS="-I${temp_path}/include"
+  cp mount.cifs ${BOSH_INSTALL_TARGET}
+popd

--- a/packages/cifs-utils/spec
+++ b/packages/cifs-utils/spec
@@ -1,0 +1,11 @@
+---
+name: cifs-utils
+
+files:
+  - autoconf-2.69.tar.gz
+  - automake-1.15.tar.gz
+  - libtool-2.4.6.tar.gz
+  - talloc-2.1.9.tar.gz
+  - pkg-config-0.29.2.tar.gz
+  - cifs-utils-6.7.tar.bz2
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables the ability to create CIFS volumes for Azure Files or FlexVolumes by including CIFS utils (and the `mount.cifs` command).

**How can this PR be verified?**
With the 0.23.0 CFCR's Azure support, use an Azure File StorageClass provisioner:
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/aks/azure-files-dynamic-pv.md

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
This may be best captured in a regression test along with other volume types tested.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**

**Release note**:
```Added support for mounting CIFS volumes```