### PR TITLE
Allow full configuration of Kubernetes Cloud Config

### DIFF
--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -1,222 +1,30 @@
 ---
 name: cloud-provider
 
-packages:
-- pid_utils
-
 provides:
 - name: cloud-provider
   type: cloud-provider
   properties:
+  - cloud-config
+  - cloud-provider
   - cloud-provider.type
-  - cloud-provider.aws.access_key_id
-  - cloud-provider.aws.secret_access_key
-  - cloud-provider.gce.network-name
-  - cloud-provider.gce.subnetwork-name
-  - cloud-provider.gce.project-id
-  - cloud-provider.gce.service_key
-  - cloud-provider.gce.worker-node-tag
-  - cloud-provider.openstack.auth-url
-  - cloud-provider.openstack.bs-version
-  - cloud-provider.openstack.ca-file
-  - cloud-provider.openstack.domain-id
-  - cloud-provider.openstack.domain-name
-  - cloud-provider.openstack.ignore-volume-az
-  - cloud-provider.openstack.password
-  - cloud-provider.openstack.region
-  - cloud-provider.openstack.tenant-id
-  - cloud-provider.openstack.tenant-name
-  - cloud-provider.openstack.trust-device-path
-  - cloud-provider.openstack.trust-id
-  - cloud-provider.openstack.username
-  - cloud-provider.vsphere.datacenter
-  - cloud-provider.vsphere.datastore
-  - cloud-provider.vsphere.insecure-flag
-  - cloud-provider.vsphere.password
-  - cloud-provider.vsphere.port
-  - cloud-provider.vsphere.resourcepool-path
-  - cloud-provider.vsphere.scsicontrollertype
-  - cloud-provider.vsphere.server
-  - cloud-provider.vsphere.user
-  - cloud-provider.vsphere.vm-uuid
-  - cloud-provider.vsphere.working-dir
-  - cloud-provider.azure.cloud
-  - cloud-provider.azure.subscription-id
-  - cloud-provider.azure.tenant-id
-  - cloud-provider.azure.service-principal-id
-  - cloud-provider.azure.service-principal-secret
-  - cloud-provider.azure.location
-  - cloud-provider.azure.use-managed-identity-extension
-  - cloud-provider.azure.resource-group-name
-  - cloud-provider.azure.vnet-resource-group-name
-  - cloud-provider.azure.vnet-name
-  - cloud-provider.azure.subnet-name
-  - cloud-provider.azure.network-security-group-name
-  - cloud-provider.azure.route-table-name
-  - cloud-provider.azure.availability-set
-  - cloud-provider.azure.vm-type
-  - cloud-provider.azure.primary-scale-set-name
-  - cloud-provider.azure.cloud-provider-back-off
-  - cloud-provider.azure.cloud-provider-backoff-retries
-  - cloud-provider.azure.cloud-provider-backoff-exponent
-  - cloud-provider.azure.cloud-provider-backoff-duration
-  - cloud-provider.azure.cloud-provider-backoff-jitter
-  - cloud-provider.azure.cloud-provider-rate-limit
-  - cloud-provider.azure.cloud-provider-rate-limit-qps
-  - cloud-provider.azure.cloud-provider-rate-limit-bucket
-  - cloud-provider.azure.cloud-provider-rate-limit-qps-write
-  - cloud-provider.azure.cloud-provider-rate-limit-bucket-write
-  - cloud-provider.azure.use-instance-metadata
-  - cloud-provider.azure.load-balancer-sku
-  - cloud-provider.azure.exclude-master-from-standardlb
-  - cloud-provider.azure.maximum-load-balancer-rule-count
 
 properties:
+  cloud-config:
+    description: "The properties to be placed into the cloud-config. The first level is a header, the second level the properties under the header"
+    example: |
+      Global:
+        user: <username>
+        password: <password>
+        port: <port>
+  cloud-provider:
+    description: "The generic properties used on a per-cloud basis"
+    example: |
+      cloud-provider:
+        type: aws
+        aws:
+          access_key_id: <access key>
+          secret_access_key: <secret key>
   cloud-provider.type:
-    description: "Type of Cloud Provider to use"
-    example: gce, vsphere, openstack
-
-  # AWS specific properties
-  cloud-provider.aws.access_key_id:
-    description: AWS access key ID that is used by cloud-provider.
-  cloud-provider.aws.secret_access_key:
-    description: AWS secret access key that is used by cloud-provider.
-
-  # GCE specific properties
-  cloud-provider.gce.project-id:
-    description: Google Cloud project id. Required when cloud-provider.type is gce.
-  cloud-provider.gce.network-name:
-    description: Google Cloud network name. Required when cloud-provider.type is gce.
-  cloud-provider.gce.subnetwork-name:
-    description: Google Cloud subnet name. Optional, used for internal load balancers.
-  cloud-provider.gce.worker-node-tag:
-    description: Google Cloud tag that identifies only worker nodes in this deployment.
-  cloud-provider.gce.service_key:
-    description: Google Cloud service key that is used by cloud-provider.
-
-  # Azure specific properties
-  cloud-provider.azure.cloud:
-    description: Microsoft Azure cloud id. Defaults to AzurePublicCloud, can also be AzureUSGovernmentCloud, AzureChinaCloud, or AzureGermanCloud. Required when cloud-provider.type is azure
-    default: "AzurePublicCloud"
-  cloud-provider.azure.subscription-id:
-    description: Microsoft Azure subscription id.  Required when cloud-provider.type is azure
-  cloud-provider.azure.tenant-id:
-    description: Microsoft Azure tenant id.  Required when cloud-provider.type is azure
-  cloud-provider.azure.service-principal-id:
-    description: Microsoft Azure service principal uuid.  Required when cloud-provider.type is azure
-  cloud-provider.azure.service-principal-secret:
-    description: Microsoft Azure service principal secret.  Required when cloud-provider.type is azure
-  cloud-provider.azure.location:
-    description: Microsoft Azure datacenter location for the Kubernetes cluster.  Required when cloud-provider.type is azure
-  cloud-provider.azure.use-managed-identity-extension:
-    description: Use managed service identity for the virtual machine to access Azure ARM APIs
-  cloud-provider.azure.resource-group-name:
-    description: Microsoft Azure resource group name for the Kubernetes cluster.  Disks and Load Balancers will be created here.  Required when cloud-provider.type is azure
-  cloud-provider.azure.vnet-resource-group-name:
-    description: Microsoft Azure resource group that includes the Virtual Network.  Required when cloud-provider.type is azure
-  cloud-provider.azure.vnet-name:
-    description: Microsoft Azure Virtual Network name.  Optionally prefixed with resource group name, i.e. "resource_group.vnet_name". Required when cloud-provider.type is azure
-  cloud-provider.azure.subnet-name:
-    description: Microsoft Azure subnet name.  Must be part of the virtual network.   required when cloud-provider.type is azure
-  cloud-provider.azure.network-security-group-name:
-    description: Microsoft Azure network security group that is attached to the subnet.  This will be be used to manage rules for Load Balancers.  Required when cloud-provider.type is azure
-  cloud-provider.azure.route-table-name:
-    description: Microsoft Azure route table that is attached to the subnet.  Used for managed routes.  Optional when cloud-provider.type is azure
-  cloud-provider.azure.availability-set:
-    description: Microsoft Azure availability set for the cluster worker nodes.  Required when cloud-provider.type is azure
-  cloud-provider.azure.vm-type:
-    description: The type of azure nodes, Candidate values are vmss and standard.
-  cloud-provider.azure.primary-scale-set-name:
-    description: The name of the scale set that should be used as the load balancer backend.
-  cloud-provider.azure.cloud-provider-back-off:
-    description: Enable exponential backoff to manage resource request retries
-  cloud-provider.azure.cloud-provider-backoff-retries:
-    description: Backoff retry limit
-  cloud-provider.azure.cloud-provider-backoff-exponent:
-    description: Backoff exponent
-  cloud-provider.azure.cloud-provider-backoff-duration:
-    description: Backoff duration
-  cloud-provider.azure.cloud-provider-backoff-jitter:
-    description: Backoff jitter
-  cloud-provider.azure.cloud-provider-rate-limit:
-    description: Enable rate limiting
-  cloud-provider.azure.cloud-provider-rate-limit-qps:
-    description: Rate limit QPS (Read)
-  cloud-provider.azure.cloud-provider-rate-limit-bucket:
-    description: Rate limit Bucket Size
-  cloud-provider.azure.cloud-provider-rate-limit-qps-write:
-    description: Rate limit QPS (Write)
-  cloud-provider.azure.cloud-provider-rate-limit-bucket-write:
-    description: Rate limit Bucket Size
-  cloud-provider.azure.use-instance-metadata:
-    description: Use instance metadata service where possible
-  cloud-provider.azure.load-balancer-sku:
-    description: Sku of Load Balancer and Public IP. Candidate values are basic and standard.
-  cloud-provider.azure.exclude-master-from-standardlb:
-    description: ExcludeMasterFromStandardLB excludes master nodes from standard load balancer.
-  cloud-provider.azure.maximum-load-balancer-rule-count:
-    description: Maximum allowed LoadBalancer Rule Count is the limit enforced by Azure Load balancer
-
-  # vSphere specific properties
-  cloud-provider.vsphere.user:
-    description: User name for vCenter
-  cloud-provider.vsphere.password:
-    description: Password for vCenter
-  cloud-provider.vsphere.server:
-    description: IP/URL for vCenter
-  cloud-provider.vsphere.port:
-    description: Default 443 for vCenter
-    default: 443
-  cloud-provider.vsphere.insecure-flag:
-    description: set to 1 if the host above uses a self-signed cert
-    default: 0
-  cloud-provider.vsphere.datacenter:
-    description: Datacenter to be used
-  cloud-provider.vsphere.datastore:
-    description: Datastore to use for provisioning volumes using storage classes/dynamic provisioning
-  cloud-provider.vsphere.working-dir:
-    description: Folder in which VMs are provisioned
-  cloud-provider.vsphere.vm-uuid:
-    description: VM Instance UUID of virtual machine which can be retrieved from instanceUuid property in VmConfigInfo, or also set as vc.uuid in VMX file. If empty, will be retrieved from sysfs (requires root)
-  cloud-provider.vsphere.scsicontrollertype:
-    description: vSphere vSCSI adapter type name
-    default: pvscsi
-  cloud-provider.vsphere.resourcepool-path:
-    description: Path to resource pool for volume creation
-    example: /data_center/host/cluster
-
-  # OpenStack specific properties
-  cloud-provider.openstack.auth-url:
-    description: The URL of the keystone API used to authenticate.
-  cloud-provider.openstack.username:
-    description: Refers to the username of a valid user set in keystone.
-  cloud-provider.openstack.password:
-    description: Refers to the password of a valid user set in keystone.
-  cloud-provider.openstack.tenant-id:
-    description: Used to specify the id of the project where you want to create your resources.
-  cloud-provider.openstack.tenant-name:
-    description: Used to specify the name of the project where you want to create your resources (Optional).
-    default: ''
-  cloud-provider.openstack.trust-id:
-    description: Used to specify the identifier of the trust to use for authorization (Optional).
-    default: ''
-  cloud-provider.openstack.domain-id:
-    description: Used to specify the id of the domain your user belongs to (Optional).
-    default: ''
-  cloud-provider.openstack.domain-name:
-    description: Used to specify the name of the domain your user belongs to (Optional).
-    default: ''
-  cloud-provider.openstack.region:
-    description: Used to specify the identifier of the region to use when running on a multi-region OpenStack cloud (Optional).
-    default: ''
-  cloud-provider.openstack.ca-file:
-    description: CA file to connect to your OpenStack cluster (Optional).
-  cloud-provider.openstack.bs-version:
-    description: Block-storage version. Valid values are v1, v2, v3 and auto. Default to auto (Optional).
-    default: auto
-  cloud-provider.openstack.trust-device-path:
-    description: By default block device names provided by Cinder (e.g. /dev/vda) can not be trusted. True toggle this behavior (Optional).
-    default: false
-  cloud-provider.openstack.ignore-volume-az:
-    description: When Nova and Cinder have different availability zones, this should be set to true. Default to false (Optional).
-    default: false
+    description: "The type of cloud-provider to use"
+    example: AWS, GCE, OpenStack, vSphere, etc.

--- a/jobs/cloud-provider/spec
+++ b/jobs/cloud-provider/spec
@@ -11,14 +11,14 @@ provides:
 
 properties:
   cloud-config:
-    description: "The properties to be placed into the cloud-config. The first level is a header, the second level the properties under the header"
+    description: The properties to be placed into the cloud-config. The first level is a header, the second level the properties under the header
     example: |
       Global:
         user: <username>
         password: <password>
         port: <port>
   cloud-provider:
-    description: "The generic properties used on a per-cloud basis"
+    description: The generic properties used on a per-cloud basis
     example: |
       cloud-provider:
         type: aws
@@ -26,5 +26,5 @@ properties:
           access_key_id: <access key>
           secret_access_key: <secret key>
   cloud-provider.type:
-    description: "The type of cloud-provider to use"
+    description: The type of cloud-provider to use
     example: AWS, GCE, OpenStack, vSphere, etc.

--- a/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
+++ b/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
@@ -1,11 +1,14 @@
-<%=
+<%
+  cloud_config=""
+
   if_link('cloud-provider') do |cloud_provider|
     cloud_provider.p('cloud-config').each do |header, properties|
-      puts "[#{header}]"
+      cloud_config += "[#{header}]\n"
       properties.each do |property, value|
         raise "Invalid value of type #{value.class} for property \"#{property}\"" unless value.is_a? String
-        puts "#{property}=#{value}"
+        cloud_config += "#{property}=#{value}\n"
       end
     end
   end
 %>
+<%= cloud_config %>

--- a/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
+++ b/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
@@ -1,107 +1,11 @@
-<%
-  cloud_config_string = ""
-  disk_config_string = ""
-  workspace_config_string = ""
-  cloud_config = {}
-  disk_config = {}
-  workspace_config = {}
-
-  cloud_config_string = "[Random]\n"
+<%=
   if_link('cloud-provider') do |cloud_provider|
-    cloud_config_string = "[Global]\n"
-    cloud_provider.if_p('cloud-provider.type') do |provider_type|
-      if provider_type == 'gce'
-        cloud_config['project-id'] = cloud_provider.p('cloud-provider.gce.project-id')
-        cloud_config['network-name'] = cloud_provider.p('cloud-provider.gce.network-name')
-        cloud_provider.if_p('cloud-provider.gce.subnetwork-name') { |path| cloud_config['subnetwork-name'] = path }
-        cloud_provider.if_p('cloud-provider.gce.service_key') { cloud_config['token-url'] = 'nil' }
-        cloud_provider.if_p('cloud-provider.gce.worker-node-tag') { |tag| cloud_config['node-tags'] = tag  }
-        cloud_config['multizone'] = true
-      elsif provider_type == 'vsphere' && spec['name'].include?("master")
-        cloud_config['user'] = '"' + cloud_provider.p('cloud-provider.vsphere.user').gsub('\\','\\\\\\') + '"'
-
-        password = ""
-        cloud_provider.p('cloud-provider.vsphere.password').split("").each do |i|
-        # check for / and "
-        if i == '"' or i == '\\'
-          password += '\\' + i
-        else
-          password += i
-        end
-        end
-        cloud_config['password'] = '"' + password + '"' # To support special chars in password
-        cloud_config['server'] = cloud_provider.p('cloud-provider.vsphere.server')
-        cloud_config['port'] = cloud_provider.p('cloud-provider.vsphere.port')
-        cloud_config['insecure-flag'] = cloud_provider.p('cloud-provider.vsphere.insecure-flag')
-        cloud_config['datacenter'] = cloud_provider.p('cloud-provider.vsphere.datacenter')
-        cloud_provider.if_p('cloud-provider.vsphere.datastore') { |datastore| cloud_config['datastore'] = datastore }
-        cloud_config['working-dir'] = cloud_provider.p('cloud-provider.vsphere.working-dir')
-        cloud_config['vm-uuid'] = cloud_provider.p('cloud-provider.vsphere.vm-uuid', '')
-
-        disk_config_string="[Disk]\n"
-        disk_config['scsicontrollertype'] = cloud_provider.p('cloud-provider.vsphere.scsicontrollertype')
-
-        workspace_config_string="[Workspace]\n"
-        cloud_provider.if_p('cloud-provider.vsphere.resourcepool-path') { |path| workspace_config['resourcepool-path'] = path }
-      elsif provider_type == 'azure'
-        cloud_config['cloud'] = cloud_provider.p('cloud-provider.azure.cloud')
-        cloud_config['tenantId'] = cloud_provider.p('cloud-provider.azure.tenant-id')
-        cloud_config['aadClientId'] = cloud_provider.p('cloud-provider.azure.service-principal-id')
-        cloud_config['aadClientSecret'] = cloud_provider.p('cloud-provider.azure.service-principal-secret')
-        cloud_config['subscriptionId'] = cloud_provider.p('cloud-provider.azure.subscription-id')
-        cloud_config['resourceGroup'] = cloud_provider.p('cloud-provider.azure.resource-group-name')
-        cloud_config['location'] = cloud_provider.p('cloud-provider.azure.location')
-        cloud_provider.if_p('cloud-provider.azure.use-managed-identity-extension') { |umie| cloud_config['useManagedIdentityExtension'] = umie }
-        cloud_config['vnetName'] = cloud_provider.p('cloud-provider.azure.vnet-name')
-        cloud_config['vnetResourceGroup'] = cloud_provider.p('cloud-provider.azure.vnet-resource-group-name')
-        cloud_config['subnetName'] = cloud_provider.p('cloud-provider.azure.subnet-name')
-        cloud_config['securityGroupName'] = cloud_provider.p('cloud-provider.azure.network-security-group-name')
-        cloud_provider.if_p('cloud-provider.azure.use-instance-metadata') { |uim| cloud_config['useInstanceMetadata'] = uim }
-        cloud_provider.if_p('cloud-provider.azure.availability-set') { |as| cloud_config['primaryAvailabilitySetName'] = as }
-        cloud_provider.if_p('cloud-provider.azure.vm-type') { |vm_type| cloud_config['vmType'] = vm_type }
-        cloud_provider.if_p('cloud-provider.azure.primary-scale-set-name') { |pssn| cloud_config['primaryScaleSetName'] = pssn }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-back-off') { |cpbo| cloud_config['cloudProviderBackoff'] = cpbo }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-backoff-retries') { |cpbr| cloud_config['cloudProviderBackoffRetries'] = cpbr }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-backoff-exponent') { |cpbe| cloud_config['cloudProviderBackoffExponent'] = cpbe }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-backoff-duration') { |cpbd| cloud_config['cloudProviderBackoffDuration'] = cpbd }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-backoff-jitter') { |cpbj| cloud_config['cloudProviderBackoffJitter'] = cpbj }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-rate-limit') { |cprl| cloud_config['cloudProviderRateLimit'] = cprl }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-rate-limit-qps') { |cprlq| cloud_config['cloudProviderRateLimitQPS'] = cprlq }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-rate-limit-bucket') { |cprlb| cloud_config['cloudProviderRateLimitBucket'] = cprlb }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-rate-limit-qps-write') { |cprlqw| cloud_config['cloudProviderRateLimitQPSWrite'] = cprlqw }
-        cloud_provider.if_p('cloud-provider.azure.cloud-provider-rate-limit-bucket-write') { |cprlbw| cloud_config['cloudProviderRateLimitBucketWrite'] = cprlbw }
-        cloud_provider.if_p('cloud-provider.azure.load-balancer-sku') { |lbs| cloud_config['loadBalancerSku'] = lbs }
-        cloud_provider.if_p('cloud-provider.azure.exclude-master-from-standardlb') { |emfs| cloud_config['excludeMasterFromStandardLB'] = emfs }
-        cloud_provider.if_p('cloud-provider.azure.maximum-load-balancer-rule-count') { |mlbrc| cloud_config['maximumLoadBalancerRuleCount'] = mlbrc }
-
-      elsif provider_type == 'openstack'
-        cloud_config['auth-url'] = cloud_provider.p('cloud-provider.openstack.auth-url')
-        cloud_config['username'] = cloud_provider.p('cloud-provider.openstack.username')
-        cloud_config['password'] = cloud_provider.p('cloud-provider.openstack.password')
-        cloud_config['tenant-id'] = cloud_provider.p('cloud-provider.openstack.tenant-id')
-        cloud_config['tenant-name'] = cloud_provider.p('cloud-provider.openstack.tenant-name')
-        cloud_config['trust-id'] = cloud_provider.p('cloud-provider.openstack.trust-id')
-        cloud_config['domain-id'] = cloud_provider.p('cloud-provider.openstack.domain-id')
-        cloud_config['domain-name'] = cloud_provider.p('cloud-provider.openstack.domain-name')
-        cloud_config['region'] = cloud_provider.p('cloud-provider.openstack.region')
-        cloud_provider.if_p('cloud-provider.openstack.ca-file') { cloud_config['ca-file'] = '/var/vcap/jobs/cloud-provider/config/openstack-ca.crt' }
-
-        disk_config_string="[BlockStorage]\n"
-        disk_config['bs-version'] = cloud_provider.p('cloud-provider.openstack.bs-version')
-        disk_config['trust-device-path'] = cloud_provider.p('cloud-provider.openstack.trust-device-path')
-        disk_config['ignore-volume-az'] = cloud_provider.p('cloud-provider.openstack.ignore-volume-az')
+    cloud_provider.p('cloud-config').each do |header, properties|
+      puts "[#{header}]"
+      properties.each do |property, value|
+        raise "Invalid value of type #{value.class} for property \"#{property}\"" unless value.is_a? String
+        puts "#{property}=#{value}"
       end
-
-      if provider_type == 'azure'
-        cloud_config_string = cloud_config.to_yaml
-      else
-        cloud_config.each { |key, prop| cloud_config_string = cloud_config_string + "#{key}=#{prop}\n" }
-        disk_config.each { |key, prop| disk_config_string = disk_config_string + "#{key}=#{prop}\n" }
-        workspace_config.each { |key, prop| workspace_config_string = workspace_config_string + "#{key}=#{prop}\n" }
-      end
-   end
+    end
   end
 %>
-<%= cloud_config_string %>
-<%= disk_config_string %>
-<%= workspace_config_string %>

--- a/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
+++ b/jobs/kube-apiserver/templates/config/cloud-provider.ini.erb
@@ -2,11 +2,15 @@
   cloud_config=""
 
   if_link('cloud-provider') do |cloud_provider|
-    cloud_provider.p('cloud-config').each do |header, properties|
-      cloud_config += "[#{header}]\n"
-      properties.each do |property, value|
-        raise "Invalid value of type #{value.class} for property \"#{property}\"" unless value.is_a? String
-        cloud_config += "#{property}=#{value}\n"
+    if cloud_provider.p('cloud-provider.type').downcase == "azure"
+      cloud_config += cloud_provider.p('cloud-config').to_yaml
+    else
+      cloud_provider.p('cloud-config').each do |header, properties|
+        cloud_config += "[#{header}]\n"
+        properties.each do |property, value|
+          raise TypeError, "Invalid value of type #{value.class} for property \"#{property}\"" unless value.is_a? String
+          cloud_config += "#{property}=#{value}\n"
+        end
       end
     end
   end

--- a/spec/cloud_provider_ini_spec.rb
+++ b/spec/cloud_provider_ini_spec.rb
@@ -18,158 +18,35 @@ describe 'cloud-provider-ini' do
   end
   let(:rendered_template) { compiled_template('kube-apiserver', 'config/cloud-provider.ini', {}, link_spec, instance_name: 'master') }
 
-  context 'if cloud provider is gce' do
-    let(:properties) { { 'cloud-provider' => { 'type' => 'gce', 'gce' => gce_config } } }
-    let(:gce_config) { { 'project-id' => 'fake-project-id', 'network-name' => 'fake-network-name', 'service_key' => 'foo', 'worker-node-tag' => 'fake-worker-node-tag' } }
+  context 'passes through the cloud-config options as expected' do
+    let(:properties)   { { 'cloud-provider' => { 'type' => 'garbage' }, 'cloud-config' => cloud_config } }
+    let(:cloud_config) { { 'Global' => { 'foo' => 'bar', 'thing' => 'another' }, 'Random' => { 'junk' => 'food' } } }
 
-    it 'renders the correct template for gce' do
-      expect(rendered_template).to include('project-id=fake-project-id')
-      expect(rendered_template).to include('network-name=fake-network-name')
-      expect(rendered_template).to include('node-tags=fake-worker-node-tag')
-    end
-
-    it 'defines the multi-az property' do
-      expect(rendered_template).to include('multizone=true')
-    end
-
-    it 'sets token-url to nil if service_key is set' do
-      expect(rendered_template).to include('token-url=nil')
-    end
-
-    context 'if gce service key not defined' do
-      let(:gce_config) { { 'project-id' => 'fake-project-id', 'network-name' => 'fake-network-name', 'worker-node-tag' => 'fake-worker-node-tag' } }
-
-      it 'does not set token-url to nil' do
-        expect(rendered_template).not_to include('token-url=nil')
-      end
-    end
-
-    context 'if subnetwork-name is provider' do
-      let(:gce_config) do
-        {
-          'project-id' => 'fake-project-id',
-          'network-name' => 'fake-network-name',
-          'subnetwork-name' => 'real-subnetwork-name',
-          'worker-node-tag' => 'fake-worker-node-tag'
-        }
-      end
-
-      it 'is added to the cloud provider config' do
-        expect(rendered_template).to include('subnetwork-name=real-subnetwork-name')
-      end
+    it 'renders the cloud-config options into the ini format' do
+      expect(rendered_template).to include('[Global]')
+      expect(rendered_template).to include('foo=bar')
+      expect(rendered_template).to include('thing=another')
+      expect(rendered_template).to include('[Random]')
+      expect(rendered_template).to include('junk=food')
     end
   end
 
-  context 'if cloud provider is vsphere' do
-    let(:properties) { { 'cloud-provider' => { 'type' => 'vsphere', 'vsphere' => vsphere_config } } }
-    let(:vsphere_config) do
-      {
-        'user' => 'fake-user',
-        'password' => 'fake-password',
-        'server' => 'fake-server',
-        'port' => 'fake-port',
-        'insecure-flag' => 'fake-insecure-flag',
-        'datacenter' => 'fake-datacenter',
-        'datastore' => 'fake-datastore',
-        'working-dir' => 'fake-working-dir',
-        'vm-uuid' => 'fake-vm-uuid',
-        'scsicontrollertype' => 'fake-scsicontrollertype',
-        'resourcepool-path' => '/fake-datacenter/host/cluster'
-      }
-    end
+  context 'errors on non-string arguments for sub-parameters' do
+    let(:properties)   { { 'cloud-provider' => { 'type' => 'garbage' }, 'cloud-config' => cloud_config } }
+    let(:cloud_config) { { 'Global' => { 'foo' => ['bar', 'baz'] } } }
 
-    context 'and when the instance group is worker' do
-      it 'renders empty cloud provider' do
-        rendered_template_worker = compiled_template('kube-apiserver', 'config/cloud-provider.ini', {}, link_spec, instance_name: 'worker')
-        expect(rendered_template_worker).to eq("\n[Global]\n\n\n\n")
-      end
-    end
-
-    it 'renders the correct template for vsphere' do
-      vsphere_config.each do |k, v|
-        if %w[password user].include? k
-          expect(rendered_template).to include("#{k}=\"#{v}\"")
-        else
-          expect(rendered_template).to include("#{k}=#{v}")
-        end
-      end
-    end
-
-    context 'user in the form domain\user' do
-      it 'has a double backslash in the template' do
-        vsphere_config['user'] = 'domain\fake-user'
-        # In the following case \\\\ appears as \\ in the actual config
-        # this is because we cannot do a string with an unescaped \ in Ruby
-        expect(rendered_template).to include('user="domain\\\\fake-user"')
-      end
-    end
-
-    context 'password has a special character #' do
-      it 'has a special character in the rendered template' do
-        vsphere_config['password'] = 'foo#bar'
-        expect(rendered_template).to include('password="foo#bar"')
-      end
-    end
-
-    context 'password has a special character "' do
-      it 'has a special character in the rendered template' do
-        vsphere_config['password'] = 'foo"bar'
-        expect(rendered_template).to include('password="foo\\"bar"')
-      end
-    end
-
-    context 'password has multiple special characters' do
-      it 'has a special character in the rendered template' do
-        vsphere_config['password'] = %(x123#$%^&*')
-        expect(rendered_template).to include("password=\"x123#\$%^&*'")
-      end
+    it 'should raise a TypeError' do
+      expect { rendered_template }.to raise_error(TypeError)
     end
   end
 
-  context 'if cloud provider is openstack' do
-    let(:properties) { { 'cloud-provider' => { 'type' => 'openstack', 'openstack' => openstack_config } } }
-    let(:required_openstack_config) { { 'auth-url' => 'fake-url', 'username' => 'fake-username', 'password' => 'fake-password', 'tenant-id' => 'fake-tenant-id' } }
-    let(:optional_openstack_config) do
-      {
-        'tenant-name' => 'fake-tenant-name',
-        'trust-id' => 'fake-trust-id',
-        'domain-id' => 'fake-domain-id',
-        'domain-name' => 'fake-domain-name',
-        'region' => 'fake-region',
-        'ca-file' => 'fake-perm-file',
-        'bs-version' => 'fake-bs-version',
-        'trust-device-path' => 'fake-trust-device-path',
-        'ignore-volume-az' => 'fake-ignore-volume-az'
-      }
-    end
+  context 'Azure renders to YAML' do
+    let(:properties)   { { 'cloud-provider' => { 'type' => 'azure' }, 'cloud-config' => cloud_config } }
+    let(:cloud_config) { { 'cloud' => 'AzurePublicCloud', 'tenantId' => 'tenant' } }
 
-    context 'required properties' do
-      let(:openstack_config) { required_openstack_config }
-      it 'renders the correct template for openstack' do
-        openstack_config.each { |k, v| expect(rendered_template).to include("#{k}=#{v}") }
-        optional_openstack_config.each { |k, v| expect(rendered_template).to_not include("#{k}=#{v}") }
-      end
-
-      context 'error handling' do
-        let(:openstack_config) { required_openstack_config.delete 'auth-url' }
-        it 'errors if a required property is not specified' do
-          expect { rendered_template }.to raise_error(Bosh::Template::UnknownProperty, /Can't find property/)
-        end
-      end
-    end
-
-    context 'optional properties' do
-      let(:openstack_config) { required_openstack_config.merge optional_openstack_config }
-      it 'renders the correct template for openstack' do
-        openstack_config['ca-file'] = '/var/vcap/jobs/cloud-provider/config/openstack-ca.crt'
-        openstack_config.each { |k, v| expect(rendered_template).to include("#{k}=#{v}") }
-      end
-
-      context 'error handling' do
-        it 'does not error if an optional property is not specified' do
-          expect { rendered_template }.to_not raise_error
-        end
-      end
+    it 'should render to yaml' do
+      expect { YAML::parse(rendered_template) }.not_to raise_error()
     end
   end
+
 end


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR continues the efforts to expose Kubernetes options and features by making the cloud-config eminently configurable. Every element of the cloud-config is provided through a pass-through map of options that are translated into expect cloud-config format.

As an example, the job will look something like this:

```
    name: cloud-provider
    release: kubo
    properties:
      cloud-provider:
        type: gce
      cloud-config:
        Global:
          project-id: ((project_id))
          network-name: ((network))
          node-tags: ((director_name))-((deployment_name))-worker
```

and the underlying INI file would render as:

```
[Global]
project-id=((project-id))
network-name=((network))
node-tags=((director_name))-((deployment_name))-worker
```

In the case of Azure, the cloud-config is expected to be in YAML, so the pass-through options look slightly different:

```
    name: cloud-provider
    release: kubo
    properties:
      cloud-provider:
        type: azure
      cloud-config:
        aadClientId: ((client_id))
        aadClientSecret: ((client_secret))
        cloud: ((azure_cloud_name))
        location: ((location))
        primaryAvailabilitySetName: ((primary_availability_set))
        resourceGroup: ((resource_group_name))
        securityGroupName: ((default_security_group))
        subnetName: ((subnet_name))
        subscriptionId: ((subscription_id))
        tenantId: ((tenant_id))
        useInstanceMetadata: true
        vnetName: ((vnet_name))
        vnetResourceGroup: ((vnet_resource_group_name))
```

and the underlying YAML would render as:

```
aadClientId: ((client_id))
aadClientSecret: ((client_secret))
cloud: ((azure_cloud_name))
location: ((location))
primaryAvailabilitySetName: ((primary_availability_set))
resourceGroup: ((resource_group_name))
securityGroupName: ((default_security_group))
subnetName: ((subnet_name))
subscriptionId: ((subscription_id))
tenantId: ((tenant_id))
useInstanceMetadata: true
vnetName: ((vnet_name))
vnetResourceGroup: ((vnet_resource_group_name))
```

**How can this PR be verified?**
Deploy with a cloud-provider and observe that the manifest renders into the expected INI file. Follow up by using a cloud-provider specific bit of functionality like a Load Balancer or Persistent Volume.

**Is there any change in kubo-deployment?**
[Yes](https://github.com/cloudfoundry-incubator/kubo-deployment/pull/353).

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
Not generally, unless operators are using custom ops-files to enable other cloud-provider options not covered by the default ops-files.

Those operators will need to rewrite the ops-file to move the option to the new format.

**Which issue(s) this PR fixes:**
https://www.pivotaltracker.com/story/show/161421611

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* The Kubernetes Cloud Config now accepts pass-through arguments from the BOSH manifest. See kubo-deployment/manifest/ops-files/iaas/<iaas>/cloud-provider.yml for examples.
  * As a result of this change, certain behaviors of the release will no longer occur:
    * In vSphere, the manifest property will need to handle escapes in the username and password fields.
    * In GCP, token-url must explicitly be set to 'nil' when supplying a service-key. See kubo-deployment/manifest/ops-files/iaas/gcp/add-service-key-master.yml for an example.
    * In OpenStack, supplying the OpenStack CA file does _not_ override the OpenStack CA file path. The path needs to be hardcoded into the cloud-config option. By default, that path is `/var/vcap/jobs/cloud-provider/config/openstack-ca.crt`
```