### PR TITLE
Bump kube-apiserver file descriptors

### DIFF
--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -28,6 +28,8 @@
 processes:
 - name: kube-apiserver
   executable: /var/vcap/packages/kubernetes/bin/kube-apiserver
+  limits:
+    open_files: 65535
   args:
   - --anonymous-auth=<%= p('anonymous_auth') %>
   - --allow-privileged=<%= p('allow_privileged') %>


### PR DESCRIPTION
heavy master API usage leads to crashes otherwise

**What this PR does / why we need it**:

Heavy K8s master usage leads to increased file descriptors far beyond the default 1024.   Many distributions of Kubernetes already use 65k open files for master nodes.

**How can this PR be verified?**

Kube API Server Crashes were reported by the GPDB team during performance testing of GPDB on K8s; contact me via Slack for the thread

**Is there any change in kubo-deployment?**

No

**Is there any change in kubo-ci?**

Perhaps as a performance/load test case?

**Does this affect upgrade, or is there any migration required?**

No

**Which issue(s) this PR fixes:**

**Release note**:

```Bumps maximum open files for kube-apiserver to 65535 to better handle busy master API usage.

```
