### PR TITLE
Bump k8s 1.12.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -78,30 +78,24 @@ jq-linux64-1.5:
   size: 3027945
   object_id: 41eb1cd1-0377-4e08-5602-51e0af8b9b52
   sha: d8e36831c3c94bb58be34dd544f44a6c6cb88568
-kubernetes-1.11.3/kube-apiserver:
-  size: 185513792
-  object_id: 4c880436-6ded-49a1-4758-99584145da4a
-  sha: 1d92823bcfe71d0c694f219961276405286766be
-kubernetes-1.11.3/kube-controller-manager:
-  size: 154113026
-  object_id: 0d790d64-378a-47cc-7982-1ee222c3809d
-  sha: cddddf92038341053a2ac84a71ce2f147c453604
-kubernetes-1.11.3/kube-proxy:
-  size: 52068695
-  object_id: ecb11b3c-0ef0-4953-5602-6b7547fd4a5d
-  sha: b3c7f41171986bd45eeac5d841cee07b89544888
-kubernetes-1.11.3/kube-scheduler:
-  size: 55636875
-  object_id: 7cfc98ef-6f87-44fe-4cf1-718bf785420e
-  sha: 2a7d78c8354a38add1971dca957d28945eab10d7
-kubernetes-1.11.3/kubectl:
-  size: 55414436
-  object_id: 916cb124-bea1-4428-528d-89da5e4b7758
-  sha: 5a336ea470a0053b1893fda89a538b6197566137
-kubernetes-1.11.3/kubelet:
-  size: 163041864
-  object_id: 39062b5b-80c6-4fe8-4ac3-12c2121f15ad
-  sha: 2c24374244482fc629776366df4f416a1b25ade4
+kubernetes-1.12.2/kube-apiserver:
+  size: 192781649
+  sha: 5a6e66f81789ead2939828902b972f1eecf17883
+kubernetes-1.12.2/kube-controller-manager:
+  size: 162961401
+  sha: 4c3900a39a6741be421611b680785148e4abddf8
+kubernetes-1.12.2/kube-proxy:
+  size: 50330867
+  sha: f6245de636667f9e010f16b1a4d493135460a307
+kubernetes-1.12.2/kube-scheduler:
+  size: 57184656
+  sha: a03c9e111635aef68e71235323043e90479885ae
+kubernetes-1.12.2/kubectl:
+  size: 57352138
+  sha: 8e94e8bafdcd919a183143d6f3364b75278e277d
+kubernetes-1.12.2/kubelet:
+  size: 176648680
+  sha: a82ca0bb1c7d838ec83070f92ddda9671ee02f90
 nfs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: e1b42c34-4e88-426b-7268-99d1bdfd40c1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -80,21 +80,27 @@ jq-linux64-1.5:
   sha: d8e36831c3c94bb58be34dd544f44a6c6cb88568
 kubernetes-1.12.2/kube-apiserver:
   size: 192781649
+  object_id: 054a68f6-f80a-4a10-5ccb-d583271f051d
   sha: 5a6e66f81789ead2939828902b972f1eecf17883
 kubernetes-1.12.2/kube-controller-manager:
   size: 162961401
+  object_id: 5f9d38dc-4753-48b9-4e65-dd832f72169f
   sha: 4c3900a39a6741be421611b680785148e4abddf8
 kubernetes-1.12.2/kube-proxy:
   size: 50330867
+  object_id: 3d767ea4-bb95-4b1e-53cc-fca0d190bc8d
   sha: f6245de636667f9e010f16b1a4d493135460a307
 kubernetes-1.12.2/kube-scheduler:
   size: 57184656
+  object_id: 4abd91ad-d779-4a2e-719f-1a61d155b672
   sha: a03c9e111635aef68e71235323043e90479885ae
 kubernetes-1.12.2/kubectl:
   size: 57352138
+  object_id: 4a4fd6bc-10fa-445f-4afe-477918b22f7c
   sha: 8e94e8bafdcd919a183143d6f3364b75278e277d
 kubernetes-1.12.2/kubelet:
   size: 176648680
+  object_id: 0f398cc8-47d3-4b00-6a9a-d067c2fbd751
   sha: a82ca0bb1c7d838ec83070f92ddda9671ee02f90
 nfs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054

--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -12,6 +12,8 @@ templates:
   config/service_key.json.erb: config/service_key.json
   config/cluster-signing-ca.pem.erb: config/cluster-signing-ca.pem
   config/cluster-signing-key.pem.erb: config/cluster-signing-key.pem
+  config/kube-controller-manager-cert.pem.erb: config/kube-controller-manager-cert.pem
+  config/kube-controller-manager-private-key.pem.erb: config/kube-controller-manager-private-key.pem
 
 packages:
 - kubernetes
@@ -29,6 +31,8 @@ properties:
     description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
   tls.kubernetes:
     description: "Certificate and private key for the Kubernetes master"
+  tls.kube-controller-manager:
+    description: "Certificate and private key for serving HTTPS from kube-controller-manager"
   service-account-private-key:
     description: "Private key used to sign generated tokens"
   k8s-args:

--- a/jobs/kube-controller-manager/templates/config/kube-controller-manager-cert.pem.erb
+++ b/jobs/kube-controller-manager/templates/config/kube-controller-manager-cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kube-controller-manager.certificate') %>

--- a/jobs/kube-controller-manager/templates/config/kube-controller-manager-private-key.pem.erb
+++ b/jobs/kube-controller-manager/templates/config/kube-controller-manager-private-key.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kube-controller-manager.private_key') %>

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,6 +1,6 @@
 set -e
 
-KUBERNETES_VERSION="1.11.3"
+KUBERNETES_VERSION="1.12.2"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- kubernetes-1.11.3/*
+- kubernetes-1.12.2/*


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
This PR bumps the kubernetes binaries to v1.12.2. Additionally, it includes changes to generate a serving certificate for kube-controller-manager. v1.12.2 now requires either to have a self-signed certificate created to a specified `--cert-dir` or supply the proper certificate and private key via `--tls-cert-file` and `--tls-private-key-file`.

We opted for creating the cert and private key file because having k8s generate a self-signed cert would have required us to change `kube-controller-manager/config/bpm.yml` to allow a writable path. Also, it's pretty easy to create certs in the manifest and is in line with what we do for other components. 

**How can this PR be verified?**
Deploy a CFCR cluster with these changes. Run integration, conformance, and upgrade against it. 

**Is there any change in kubo-deployment?**
Yes: https://github.com/cloudfoundry-incubator/kubo-deployment/pull/357

**Is there any change in kubo-ci?**
Nope. 

**Does this affect upgrade, or is there any migration required?**
Yes, because its an update of the k8s binaries. 

**Which issue(s) this PR fixes:**
None. 

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* Upgraded to Kubernetes v1.12.2
* New certificate for serving HTTPS from kube-controller-manager
```
