### PR TITLE
fix CONTRIBUTING.md integration-tests dir name error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Integration tests are located in [kubo-ci](https://github.com/cloudfoundry-incub
 1. Run integration tests:
 
   ```
-  GOPATH=$PWD ginkgo -skipPackage addons -keepGoing -r src/tests/integration_tests
+  GOPATH=$PWD ginkgo -skipPackage addons -keepGoing -r src/tests/integration-tests
   ```
   
 **Note** Tests will create load balancers and persistent disks. Some tests require direct access to the kubelet nodes, but most of them just require access to Kubernetes API.


### PR DESCRIPTION

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
change CONTRIBUTING.md error dir name

**How can this PR be verified?**
```
ls src/tests/ 
config/  Gopkg.lock  Gopkg.toml  integration-tests/  test_helpers/  turbulence-tests/  upgrade-tests/  vendor/
```
docs is  `integration_tests`
**Is there any change in kubo-deployment?**
no
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
