### PR TITLE
Added backslash to end of kubelet's hardwired config flag

### DIFF
--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -127,7 +127,7 @@ start_kubelet() {
     <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> \
     --hostname-override=$(get_hostname_override) \
     --node-labels=<%= labels %> \
-    --config="/var/vcap/jobs/kubelet/config/kubeletconfig.yml"
+    --config="/var/vcap/jobs/kubelet/config/kubeletconfig.yml" \
   1>> $LOG_DIR/kubelet.stdout.log \
   2>> $LOG_DIR/kubelet.stderr.log
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the backslash back to the end of Kubelet's hardwired `--config` flag so that the log redirects underneath continue to send stderr and stdout to individual files.

**How can this PR be verified?**
Deploy the PR and observe that Kubelet stderr and stdout logs exist.

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
None.

**Release note**:

```release-note
* Reinstated Kubelet logs
```
