### PR TITLE
Adds default storage classes for Azure, AWS and vSphere

### DIFF
--- a/jobs/apply-specs/spec
+++ b/jobs/apply-specs/spec
@@ -26,6 +26,9 @@ templates:
   specs/metrics-server/resource-reader.yml: specs/metrics-server/resource-reader.yml
   specs/metrics-server/secrets.yml.erb: specs/metrics-server/secrets.yml
   specs/storage-class-gce.yml: specs/storage-class-gce.yml
+  specs/storage-class-aws.yml: specs/storage-class-aws.yml
+  specs/storage-class-azure.yml: specs/storage-class-azure.yml
+  specs/storage-class-vsphere.yml: specs/storage-class-vsphere.yml
 
 packages:
 - kubernetes

--- a/jobs/apply-specs/templates/bin/deploy-specs.erb
+++ b/jobs/apply-specs/templates/bin/deploy-specs.erb
@@ -109,6 +109,21 @@ main() {
         apply_spec "storage-class-gce.yml"
       <% end %>
     <% end %>
+    <% cloud_provider.if_p('cloud-provider.type') do |p| %>
+      <% if p == 'aws' %>
+        apply_spec "storage-class-aws.yml"
+      <% end %>
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.type') do |p| %>
+      <% if p == 'azure' %>
+        apply_spec "storage-class-azure.yml"
+      <% end %>
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.type') do |p| %>
+      <% if p == 'vsphere' %>
+        apply_spec "storage-class-vsphere.yml"
+      <% end %>
+    <% end %>
   <% end %>
   echo "System specs added successfully."
 

--- a/jobs/apply-specs/templates/specs/storage-class-aws.yml
+++ b/jobs/apply-specs/templates/specs/storage-class-aws.yml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2

--- a/jobs/apply-specs/templates/specs/storage-class-azure.yml
+++ b/jobs/apply-specs/templates/specs/storage-class-azure.yml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS

--- a/jobs/apply-specs/templates/specs/storage-class-vsphere.yml
+++ b/jobs/apply-specs/templates/specs/storage-class-vsphere.yml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata: 
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/vsphere-volume
+parameters: 
+  diskformat: thin
+  fstype: ext3

--- a/spec/apply_specs_spec.rb
+++ b/spec/apply_specs_spec.rb
@@ -72,6 +72,9 @@ describe 'apply-specs' do
 
   it 'does not apply the standard storage class by default' do
     expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-gce.yml"')
+    expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-aws.yml"')
+    expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-azure.yml"')
+    expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-vsphere.yml"')
   end
 
   context 'Mutiple CAs' do
@@ -121,6 +124,63 @@ describe 'apply-specs' do
     end
   end
 
+  context 'on AWS' do
+    let(:link_spec) do
+      {
+        'cloud-provider' => {
+          'instances' => [],
+          'properties' => {
+            'cloud-provider' => {
+              'type' => 'aws'
+            }
+          }
+        }
+      }
+    end
+
+    it 'applies the standard storage class' do
+      expect(rendered_deploy_specs).to include('apply_spec "storage-class-aws.yml"')
+    end
+  end
+
+  context 'on Azure' do
+    let(:link_spec) do
+      {
+        'cloud-provider' => {
+          'instances' => [],
+          'properties' => {
+            'cloud-provider' => {
+              'type' => 'azure'
+            }
+          }
+        }
+      }
+    end
+
+    it 'applies the standard storage class' do
+      expect(rendered_deploy_specs).to include('apply_spec "storage-class-azure.yml"')
+    end
+  end
+
+  context 'on vSphere' do
+    let(:link_spec) do
+      {
+        'cloud-provider' => {
+          'instances' => [],
+          'properties' => {
+            'cloud-provider' => {
+              'type' => 'vsphere'
+            }
+          }
+        }
+      }
+    end
+
+    it 'applies the standard storage class' do
+      expect(rendered_deploy_specs).to include('apply_spec "storage-class-vsphere.yml"')
+    end
+  end
+
   context 'on non-GCE' do
     let(:link_spec) do
       {
@@ -152,6 +212,9 @@ describe 'apply-specs' do
 
     it 'does not apply the standard storage class' do
       expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-gce.yml"')
+      expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-aws.yml"')
+      expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-azure.yml"')
+      expect(rendered_deploy_specs).to_not include('apply_spec "storage-class-vsphere.yml"')
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a default storage class for each of the currently supported IaaS types.   Today, only a GCE storageclass is created, leaving AWS, Azure and vSphere users to figure it out on their own.   This PR delivers a better out-of-the-box experience

**How can this PR be verified?**

Deploy to the relevant IaaS, and confirm the storage class exists with: `kubectl get sc`

**Is there any change in kubo-deployment?**

No

**Is there any change in kubo-ci?**

No

**Does this affect upgrade, or is there any migration required?**

No

**Which issue(s) this PR fixes:**

#286

**Release note**:

```release-note
Adds additional default storageclasses for all supported IaaS.
```
