### PR TITLE
Add support for Windows worker nodes

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,6 +14,10 @@ cni/cni-plugins-amd64-v0.7.1.tgz:
   size: 17108856
   object_id: 50dc58eb-107d-483a-4e37-5a243ffed520
   sha: fb29e20401d3e9598a1d8e8d7992970a36de5e05
+cni/cni-plugins-windows-amd64-c74e0e996.tgz:
+  size: 9678154
+  object_id: ed601155-ac1f-4682-684d-76cd6eaa1a95
+  sha: 02c4d67a17a28c26cc471e56bf01dcacd104b346
 cni/util-linux_2.27.1-6ubuntu3_amd64.deb:
   size: 847730
   object_id: 27eb3ec3-220f-4a25-6c4f-ec219c37ac8d
@@ -66,6 +70,10 @@ flannel-v0.10.0-linux-amd64.tar.gz:
   size: 9706487
   object_id: 36a8e66a-0b6c-4ca2-5f27-c277a7db90c5
   sha: 9d19a56847d6aad207671a349eddd85de87ba560
+flannel-v0.11.0-windows-amd64.tar.gz:
+  size: 9488010
+  object_id: f1a21fd3-b6c3-4f70-48c4-017e55a061c3
+  sha: 71cb61a487c40df8eeb4d2bd68d7e891b51b44bb
 ipset/ipset_6.20.1-1_amd64.deb:
   size: 34156
   object_id: 5dfcce8f-366e-49f0-59e6-9e2d48178750
@@ -102,6 +110,18 @@ kubernetes-1.13.3/kubelet:
   size: 113018904
   object_id: 7b17cc29-f681-4b19-5c95-ce6c52dc1608
   sha: 9b5d05229ba35aaed6476e7177e786c9b1fa87c0
+kubernetes-windows-1.12.5/kube-proxy.exe:
+  size: 49589248
+  object_id: 99d889a9-6a41-4bcc-7754-7f805af2f109
+  sha: eee0ff31a6fd908c83f727ad228a50b6ae8fd008
+kubernetes-windows-1.12.5/kubectl.exe:
+  size: 57638400
+  object_id: 4fa776d2-74e0-4110-429a-469d9094bed0
+  sha: c203b7181e3321511af4e378467c69c931d6bd29
+kubernetes-windows-1.12.5/kubelet.exe:
+  size: 160816128
+  object_id: f55f1065-0b8a-4273-48ae-cb58f292edea
+  sha: 6b872771cbfa278d829b178d23c1567820eeaf2b
 libmnl0_1.0.3-3.deb:
   size: 11416
   object_id: 245e085f-1ad2-447d-67bb-1894b960c571

--- a/jobs/flanneld-windows/monit
+++ b/jobs/flanneld-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "flanneld",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\flanneld-windows\\bin\\flanneld_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/flanneld-windows/spec
+++ b/jobs/flanneld-windows/spec
@@ -1,17 +1,15 @@
 ---
-name: flanneld
+name: flanneld-windows
 
 templates:
-  bin/flanneld_ctl.erb: bin/flanneld_ctl
+  bin/flanneld_ctl.ps1.erb: bin/flanneld_ctl.ps1
   config/etcd-ca.crt.erb: config/etcd-ca.crt
   config/etcd-client.crt.erb: config/etcd-client.crt
   config/etcd-client.key.erb: config/etcd-client.key
 
 packages:
-- pid_utils
-- etcdctl
-- flanneld
-- cni
+- flanneld-windows
+- cni-windows
 
 properties:
   pod-network-cidr:
@@ -19,8 +17,14 @@ properties:
     default: "10.200.0.0/16"
   backend-type:
     description: The network backend to use
-    default: "vxlan"
+    default: "win-overlay"
 
 consumes:
 - name: etcd
   type: etcd
+
+provides:
+- name: flanneld-windows
+  type: flanneld-windows
+  properties:
+  - backend-type

--- a/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
+++ b/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
@@ -1,0 +1,87 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+<%-
+  def get_url(server, port)
+    if link('etcd').p('etcd.dns_suffix', false) != false
+      node_name = "#{server.name.gsub('_','-')}-#{server.index}"
+      return "https://#{node_name}.#{link('etcd').p('etcd.dns_suffix')}:#{port}"
+    else
+      return "https://#{server.address}:#{port}"
+    end
+  end
+-%>
+<%-
+  def get_network_name
+    if p("backend-type") == "win-overlay"
+      "vxlan0"
+    else
+      "cbr0"
+    end
+  end
+-%>
+
+function start_flanneld {
+  <% etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",") %>
+
+  mkdir -force /etc/cni/net.d
+  $confFile= '
+{
+  "name": "<%= get_network_name %>",
+  "plugins": [
+    {
+      "type": "flannel",
+      "delegate": {
+        "hairpinMode": true,
+        "isDefaultGateway": true,
+        "type": "<%= p('backend-type') %>",
+        "dns": {
+          "nameservers": ["10.100.200.10"],
+          "search": ["svc.cluster.local"]
+        },
+        "policies": [
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "OutBoundNAT",
+              "ExceptionList": [
+                "<%= p('pod-network-cidr') %>",
+                "10.100.200.0/12",
+                "<%= spec.ip.split(".")[0...-1].append(0).join(".") %>/24"
+              ]
+            }
+          },
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "ROUTE",
+              "DestinationPrefix": "10.100.200.0/24",
+              "NeedEncap": true
+            }
+          },
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "ROUTE",
+              "DestinationPrefix": "<%= spec.ip %>/32",
+              "NeedEncap": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+'
+  Set-Content -Path /etc/cni/net.d/50-flannel.conflist -Value $confFile
+
+
+  /var/vcap/packages/flanneld-windows/flanneld.exe `
+    --etcd-endpoints=<%= etcd_endpoints %> `
+    --ip-masq `
+    --etcd-certfile=/var/vcap/jobs/flanneld-windows/config/etcd-client.crt `
+    --etcd-keyfile=/var/vcap/jobs/flanneld-windows/config/etcd-client.key `
+    --etcd-cafile=/var/vcap/jobs/flanneld-windows/config/etcd-ca.crt
+}
+
+start_flanneld

--- a/jobs/flanneld-windows/templates/config/etcd-ca.crt.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-ca.crt.erb
@@ -1,0 +1,2 @@
+<%= link('etcd').p('tls.etcdctl.ca') %>
+

--- a/jobs/flanneld-windows/templates/config/etcd-client.crt.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-client.crt.erb
@@ -1,0 +1,2 @@
+<%= link('etcd').p('tls.etcdctl.certificate') %>
+

--- a/jobs/flanneld-windows/templates/config/etcd-client.key.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-client.key.erb
@@ -1,0 +1,2 @@
+<%= link('etcd').p('tls.etcdctl.private_key') %>
+

--- a/jobs/flanneld/templates/bin/flanneld_ctl.erb
+++ b/jobs/flanneld/templates/bin/flanneld_ctl.erb
@@ -72,7 +72,7 @@ EOL
     --cert-file /var/vcap/jobs/flanneld/config/etcd-client.crt \
     --key-file /var/vcap/jobs/flanneld/config/etcd-client.key \
     --ca-file /var/vcap/jobs/flanneld/config/etcd-ca.crt \
-    set /coreos.com/network/config '{"Network":"<%= p('pod-network-cidr') %>","Backend":{"Type":"vxlan"}}'
+    set /coreos.com/network/config '{"Network":"<%= p('pod-network-cidr') %>","Backend":{"Type": "<%= p('backend-type') %>"}}'
 
   flanneld -etcd-endpoints=<%= etcd_endpoints %> \
     --ip-masq \

--- a/jobs/kube-proxy-windows/monit
+++ b/jobs/kube-proxy-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "kube-proxy",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\kube-proxy-windows\\bin\\kube_proxy_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/kube-proxy-windows/spec
+++ b/jobs/kube-proxy-windows/spec
@@ -1,0 +1,38 @@
+---
+name: kube-proxy-windows
+
+templates:
+  bin/kube_proxy_ctl.ps1.erb: bin/kube_proxy_ctl.ps1
+  config/kubeconfig.erb: config/kubeconfig
+  config/config.yml.erb: config/config.yml
+  config/ca.pem.erb: config/ca.pem
+
+packages:
+- kubernetes-windows
+
+properties:
+  api-token:
+    description: The password for the kube-proxy user
+  cloud-provider:
+    description: The type of cloud-provider that is being deployed
+  tls.kubernetes:
+    description: Certificate and private key for the Kubernetes master
+  kube-proxy-configuration:
+    description: The Kube-proxy will load its initial configuration from this.
+      Omit this to use the built-in default configuration values.
+      Command-line flags override configuration.
+      This is the recommended way to configure kube-proxy as the command line flags for kube-proxy are being deprecated.
+    example: |
+      kube-proxy-configuration:
+        feature-gates:
+          CPUManager: true
+          DryRun: false
+        cleanup: false
+  k8s-args:
+    description: Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ for reference.
+    example: |
+      k8s-args:
+        feature-gates:
+          CPUManager: true
+          DryRun: false
+        cleanup: false

--- a/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
+++ b/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
@@ -1,0 +1,52 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+function ensure_kubelet_is_running {
+  curl.exe --fail http://localhost:10248/healthz
+  if (-not $?) {
+    throw "kubelet is not available"
+  }
+}
+
+function start_kube_proxy {
+  $network = Get-HnsNetwork | ? Type -Eq L2Bridge
+  $env:KUBE_NETWORK = $network.Name
+
+  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
+}
+
+function check_for_networking {
+  $subnetConfig="/run/flannel/subnet.env"
+
+  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  {
+    throw "$subnetConfig does not exist, waiting for flannel initialization"
+  }
+}
+
+function misc_setup {
+  # Prestart doesn't get run again on recreate, so need to do this in ctl
+  Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+
+  <% if_p('cloud-provider') do |cloud_provider| %>
+    <% if cloud_provider == "vsphere" %>
+  # Override the hostname to work around
+  # vSphere cloud provider ignoring hostname override
+  # and kubernetes requiring all-lowercase node names
+  $ComputerName = (cat C:\var\vcap\bosh\settings.json | ConvertFrom-Json).agent_id
+  Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname" -value $ComputerName
+    <% end %>
+  <% end %>
+
+  # Needed until https://github.com/kubernetes/kubernetes/pull/71147 is merged
+  mkdir -force /sys/class/dmi/id
+  (wmic csproduct get IdentifyingNumber).Split([Environment]::Newline)[2] | Out-File -Encoding ASCII /sys/class/dmi/id/product_serial
+}
+
+function main() {
+  misc_setup
+  check_for_networking
+  start_kube_proxy
+}
+
+main

--- a/jobs/kube-proxy-windows/templates/config/ca.pem.erb
+++ b/jobs/kube-proxy-windows/templates/config/ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubernetes.ca') %>

--- a/jobs/kube-proxy-windows/templates/config/config.yml.erb
+++ b/jobs/kube-proxy-windows/templates/config/config.yml.erb
@@ -1,0 +1,13 @@
+<%
+  hostname = ""
+  if_p('cloud-provider') do |cloud_provider|
+    if cloud_provider == "gce" || cloud_provider == "azure" || cloud_provider == "vsphere"
+    else
+      hostname = spec.ip
+    end
+  end.else do
+    hostname = spec.ip
+  end
+%>
+<% require 'yaml' %><%= p('kube-proxy-configuration').to_yaml %>
+hostnameOverride: <%= hostname %>

--- a/jobs/kube-proxy-windows/templates/config/kubeconfig.erb
+++ b/jobs/kube-proxy-windows/templates/config/kubeconfig.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: "C:\\var\\vcap\\jobs\\kube-proxy-windows\\config\\ca.pem"
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kube-proxy
+  name: kube-proxy
+current-context: kube-proxy
+users:
+- name: kube-proxy
+  user:
+    token: "<%= p("api-token") %>"

--- a/jobs/kubelet-windows/monit
+++ b/jobs/kubelet-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "kubelet",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\kubelet-windows\\bin\\kubelet_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/kubelet-windows/spec
+++ b/jobs/kubelet-windows/spec
@@ -1,0 +1,64 @@
+name: kubelet-windows
+templates:
+  bin/drain.ps1.erb: bin/drain.ps1
+  bin/kubelet_ctl.ps1.erb: bin/kubelet_ctl.ps1
+  config/apiserver-ca.pem.erb: config/apiserver-ca.pem
+  config/cloud-provider.ini.erb: config/cloud-provider.ini
+  config/Dockerfile: config/Dockerfile
+  config/kubeconfig-drain.erb: config/kubeconfig-drain
+  config/kubeconfig.erb: config/kubeconfig
+  config/kubelet-client-ca.pem.erb: config/kubelet-client-ca.pem
+  config/kubelet-key.pem.erb: config/kubelet-key.pem
+  config/kubelet.pem.erb: config/kubelet.pem
+  config/kubeletconfig.yml.erb: config/kubeletconfig.yml
+  config/openstack-ca.crt.erb: config/openstack-ca.crt
+  config/service_key.json.erb: config/service_key.json
+packages:
+- kubernetes-windows
+- cni-windows
+properties:
+  api-token:
+    description: The token to access Kubernetes API
+  cloud-provider:
+    description: "The type of cloud-provider that is being deployed"
+  drain-api-token:
+    description: The token to access Kubernetes API used to drain the kubelet.
+  http_proxy:
+    description: http_proxy env var for cloud provider interactions, i.e. for the
+      kubelet
+  https_proxy:
+    description: https_proxy env var for cloud provider interactions, i.e. for the
+      kubelet
+  kubelet-configuration:
+    description: The Kubelet will load its initial configuration from this.
+      Omit this to use the built-in default configuration values.
+      Command-line flags override configuration.
+  k8s-args:
+    description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
+    example: |
+      k8s-args:
+        address: 10.0.0.1
+        docker-only: null
+  no_proxy:
+    description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
+  labels:
+    description: '<Warning: Alpha feature> Labels to add when registering the node
+      in the cluster.  Labels must be key=value pairs separated by '',''.'
+  tls.kubelet:
+    description: Certificate and private key for the Kubernetes worker
+    parameters:
+      duration: {}
+      key_length: {}
+    type: {}
+  tls.kubelet-client-ca.certificate:
+    description: CA certificate of the authority granting access to kubelet server
+  tls.kubernetes:
+    description: Certificate and private key for the Kubernetes master
+consumes:
+- name: cloud-provider
+  optional: true
+  type: cloud-provider
+provides:
+- name: kubernetes-workers
+  type: kubernetes-workers
+

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -1,0 +1,70 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$OutLog = "C:\var\vcap\sys\log\kubelet-windows\drain.stdout.log"
+$ErrLog = "C:\var\vcap\sys\log\kubelet-windows\drain.stderr.log"
+
+
+function main {
+  if (kubelet_is_running) {
+    retry "drain_kubelet" $function:drain_kubelet
+    # watch_disks TODO(BM/LH): implement this?
+    retry "delete_drained_node" $function:delete_drained_node
+  }
+  echo "0"
+}
+
+function drain_kubelet() {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain `
+    get nodes -o json | ConvertFrom-Json).Items
+  $node_name=($nodes | ? { $_.metadata.labels."bosh.id" -eq "<%= spec.id %>" }).metadata.name
+
+  if (!$node_name) {
+    return $true
+  }
+  /var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain drain "${node_name}" `
+    --grace-period 10 --force --delete-local-data --ignore-daemonsets
+  return $?
+}
+
+function delete_drained_node() {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain `
+    get nodes -o json | ConvertFrom-Json).Items
+  $node_name=($nodes | ? { $_.metadata.labels."bosh.id" -eq "<%= spec.id %>" }).metadata.name
+
+  if (!$node_name) {
+    return $true
+  }
+  /var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain delete node "${node_name}" `
+    --ignore-not-found | Out-Null
+  return $?
+}
+
+function retry($name, $func) {
+  $attempt_number=1
+  $max_attempts=10
+
+  do {
+    $result=$func.Invoke()
+    if ($result) {
+      echo "Successfully $name" | Out-File -FilePath $OutLog -encoding ascii
+      return
+    }
+    echo ("[{0}] Unsuccessful {1}, retrying attempt {2} out of {3}" -f (Get-Date -UFormat %s), $name, $attempt_number, $max_attempts) | Out-File -FilePath $OutLog -encoding ascii
+    $attempt_number=$attempt_number + 1
+    sleep 1
+  } while ($attempt_number -le $max_attempts)
+
+  throw "Failed all retry attempts for $name"
+}
+
+function kubelet_is_running() {
+  curl.exe --silent --fail http://localhost:10248/healthz
+  return $?
+}
+
+main

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -1,0 +1,162 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$env:PATH+=";C:\var\vcap\packages\docker\docker\;"
+
+<% iaas = nil %>
+<% if_p('cloud-provider') do |cloud_provider| %>
+  <% iaas = cloud_provider %>
+  $cloud_provider="<%= cloud_provider %>"
+<% end %>
+
+<% if_link('cloud-provider') do |cloud_provider| %>
+    $cloud_config="/var/vcap/jobs/kubelet-windows/config/cloud-provider.ini"
+    <% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| %>
+      $env:GOOGLE_APPLICATION_CREDENTIALS="/var/vcap/jobs/kubelet-windows/config/service_key.json"
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.aws.access_key_id') do |access_key_id| %>
+      $env:AWS_ACCESS_KEY_ID="<%= access_key_id %>"
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.aws.secret_access_key') do |secret_access_key| %>
+      $env:AWS_SECRET_ACCESS_KEY="<%= secret_access_key %>"
+    <% end %>
+<% end %>
+
+<%
+  labels = ["spec.ip=#{spec.ip}","bosh.id=#{spec.id}","bosh.zone=#{spec.az}"]
+  if iaas=="vsphere"
+    labels << "failure-domain.beta.kubernetes.io/zone=#{spec.az}"
+  end
+  if_p("labels") do |node_labels|
+    labels += node_labels.map {|k,v| "#{k}=#{v}"}
+  end
+  labels = labels.join(',')
+%>
+
+<% if_p('http_proxy') do |http_proxy| %>
+$env:HTTP_PROXY=<%= http_proxy %>
+<% end %>
+<% if_p('https_proxy') do |https_proxy| %>
+$env:HTTPS_PROXY=<%= https_proxy %>
+<% end %>
+<% if_p('no_proxy') do |no_proxy| %>
+$env:NO_PROXY=<%= no_proxy %>
+<% end %>
+
+function delete_stale_drained_node {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain get nodes -o json | ConvertFrom-Json).Items
+  $nodes | ForEach-Object {
+    if ($_.metadata.labels."bosh.id" -eq "<= spec.id %>") {
+      if (($_.status.conditions | ? type -eq "Ready").status -ne "True") {
+        /var/vcap/packages/kubernetes-windows/bin/kubectl --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain delete node "${node_name}" --ignore-not-found
+      }
+    }
+  }
+}
+
+function get_hostname_override {
+  if ($cloud_provider -in "gce", "azure") {
+    return ""
+  } else {
+    return "<%= spec.ip %>"
+  }
+}
+
+function start_kubelet {
+  <%-
+    include_config = false
+    if !iaas.nil? and iaas != "vsphere"
+      if_link('cloud-provider') do
+        include_config = true
+      end
+    end
+  -%>
+
+  /var/vcap/packages/kubernetes-windows/bin/kubelet `
+  <%-
+    if_p('k8s-args') do |args|
+      args.each do |flag, value|
+        valueString = ""
+
+        if value.nil?
+          # Do nothing to supports args-less flags (--example)
+        elsif value.is_a? Array
+          valueString = "=#{value.join(",")}"
+        elsif value.is_a? Hash
+          valueString = "=#{value.map { |k,v| "#{k}=#{v}" }.join(",")}"
+        else
+          valueString = "=#{value}"
+        end
+  -%>
+    <%= "--#{flag}#{valueString}" %> `
+  <%-
+      end
+    end
+  -%>
+    <% if include_config -%>--cloud-config=${cloud_config}<% end %> `
+    <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> `
+    --hostname-override=$(get_hostname_override) `
+    --node-labels=<%= labels %> `
+    --config="/var/vcap/jobs/kubelet-windows/config/kubeletconfig.yml"
+}
+
+function check_for_networking {
+  $subnetConfig="/run/flannel/subnet.env"
+
+  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  {
+    throw "$subnetConfig does not exist, waiting for flannel initialization"
+  }
+}
+
+function ensure_kubeproxy_is_running {
+  curl.exe --fail http://localhost:10256/healthz
+  if (-not $?) {
+    throw "kube-proxy is not available"
+  }
+}
+
+function ensure_docker_is_running {
+  curl.exe --fail http://localhost:10256/healthz
+  if (-not $?) {
+    throw "kube-proxy is not available"
+  }
+}
+
+function load_base_images {
+  # Temporary workaround until we bring our own images
+  docker version
+  if (-not $?) {
+    throw "docker is not available"
+  }
+  docker pull mcr.microsoft.com/windows/nanoserver:1803
+  docker pull mcr.microsoft.com/windows/servercore:1803
+
+  if (!(docker images mcr.microsoft.com/windows/nanoserver:latest -q))
+  {
+    docker tag (docker images mcr.microsoft.com/windows/nanoserver -q) mcr.microsoft.com/windows/nanoserver
+  }
+
+  if (!(docker images mcr.microsoft.com/windows/servercore:latest -q))
+  {
+    docker tag (docker images mcr.microsoft.com/windows/servercore -q) mcr.microsoft.com/windows/servercore
+  }
+
+  $infraPodImage=docker images kubeletwin/pause -q
+  if (!$infraPodImage)
+  {
+    cd /var/vcap/jobs/kubelet-windows/config
+    docker build -t kubeletwin/pause .
+  }
+}
+
+function main {
+  delete_stale_drained_node
+  check_for_networking
+  ensure_docker_is_running
+  ensure_kubeproxy_is_running
+  load_base_images
+  start_kubelet
+}
+
+main

--- a/jobs/kubelet-windows/templates/bin/post-start.ps1
+++ b/jobs/kubelet-windows/templates/bin/post-start.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+function kubelet_is_running() {
+  curl.exe --fail http://localhost:10248/healthz
+  return $?
+}
+
+function main() {
+    retry "passed kubelet healthcheck" $function:kubelet_is_running
+}
+
+function retry($name, $func) {
+  $attempt_number=1
+  $max_attempts=10
+
+  do {
+    $result=$func.Invoke()
+    if ($result) {
+      echo "Successfully $name"
+      return $true
+    }
+    echo ("[{0}] Unsuccessful {1}, retrying attempt {2} out of {3}" -f (Get-Date -UFormat %s), $name, $attempt_number, $max_attempts)
+    $attempt_number=$attempt_number + 1
+    sleep 1
+  } while ($attempt_number -le $max_attempts)
+
+  echo "Failed all retry attempts for $name"
+  return $false
+}

--- a/jobs/kubelet-windows/templates/config/Dockerfile
+++ b/jobs/kubelet-windows/templates/config/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/nanoserver
+
+CMD cmd /c ping -t localhost

--- a/jobs/kubelet-windows/templates/config/apiserver-ca.pem.erb
+++ b/jobs/kubelet-windows/templates/config/apiserver-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubernetes.ca') %>

--- a/jobs/kubelet-windows/templates/config/cloud-provider.ini.erb
+++ b/jobs/kubelet-windows/templates/config/cloud-provider.ini.erb
@@ -1,0 +1,1 @@
+../../../kube-apiserver/templates/config/cloud-provider.ini.erb

--- a/jobs/kubelet-windows/templates/config/kubeconfig-drain.erb
+++ b/jobs/kubelet-windows/templates/config/kubeconfig-drain.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: C:\var\vcap\jobs\kubelet-windows\config\apiserver-ca.pem
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet-drain
+  name: kubelet-drain
+current-context: kubelet-drain
+users:
+- name: kubelet-drain
+  user:
+    token: "<%= p("drain-api-token") %>"

--- a/jobs/kubelet-windows/templates/config/kubeconfig.erb
+++ b/jobs/kubelet-windows/templates/config/kubeconfig.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: C:\var\vcap\jobs\kubelet-windows\config\apiserver-ca.pem
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+  user:
+    token: "<%= p("api-token") %>"

--- a/jobs/kubelet-windows/templates/config/kubelet-client-ca.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet-client-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubelet-client-ca.certificate') %>

--- a/jobs/kubelet-windows/templates/config/kubelet-key.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet-key.pem.erb
@@ -1,0 +1,1 @@
+<%= p("tls.kubelet.private_key") %>

--- a/jobs/kubelet-windows/templates/config/kubelet.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet.pem.erb
@@ -1,0 +1,2 @@
+<%= p("tls.kubelet.certificate") %>
+<%= p("tls.kubelet.ca") %>

--- a/jobs/kubelet-windows/templates/config/kubeletconfig.yml.erb
+++ b/jobs/kubelet-windows/templates/config/kubeletconfig.yml.erb
@@ -1,0 +1,1 @@
+<% require 'yaml' %><%= p('kubelet-configuration').to_yaml %>

--- a/jobs/kubelet-windows/templates/config/openstack-ca.crt.erb
+++ b/jobs/kubelet-windows/templates/config/openstack-ca.crt.erb
@@ -1,0 +1,1 @@
+../../../kube-apiserver/templates/config/openstack-ca.crt.erb

--- a/jobs/kubelet-windows/templates/config/service_key.json.erb
+++ b/jobs/kubelet-windows/templates/config/service_key.json.erb
@@ -1,0 +1,1 @@
+../../../kube-apiserver/templates/config/service_key.json.erb

--- a/packages/cni-windows/packaging
+++ b/packages/cni-windows/packaging
@@ -1,0 +1,7 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+mkdir ${env:BOSH_INSTALL_TARGET}/bin
+tar -xzf cni/cni-plugins-windows-amd64*.tgz -C ${env:BOSH_INSTALL_TARGET}/bin/

--- a/packages/cni-windows/spec
+++ b/packages/cni-windows/spec
@@ -1,0 +1,6 @@
+---
+name: cni-windows
+
+files:
+- cni/cni-plugins-windows-amd64-c74e0e996.tgz
+- exiter.ps1

--- a/packages/flanneld-windows/packaging
+++ b/packages/flanneld-windows/packaging
@@ -1,0 +1,9 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+
+$FLANNELD_VERSION="0.11.0"
+tar xvf flannel-v${FLANNELD_VERSION}-windows-amd64.tar.gz
+Copy-Item flanneld.exe "${env:BOSH_INSTALL_TARGET}/flanneld.exe"

--- a/packages/flanneld-windows/spec
+++ b/packages/flanneld-windows/spec
@@ -1,0 +1,8 @@
+---
+name: flanneld-windows
+
+dependencies:
+
+files:
+- flannel-v0.11.0-windows-amd64.tar.gz
+- exiter.ps1

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -1,0 +1,10 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$KUBERNETES_VERSION="1.12.5"
+
+New-Item -Path "${env:BOSH_INSTALL_TARGET}" -Name "bin" -ItemType "directory"
+
+Copy-Item "kubernetes-windows-${KUBERNETES_VERSION}/*" "${env:BOSH_INSTALL_TARGET}/bin"

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -1,0 +1,6 @@
+---
+name: kubernetes-windows
+
+files:
+- kubernetes-windows-1.12.5/*
+- exiter.ps1

--- a/src/exiter.ps1
+++ b/src/exiter.ps1
@@ -1,0 +1,6 @@
+exit 0
+# The reason for needing this file is to make `bosh export-release` happy.
+# BOSH doesn't know what job to export, so it tries to export a windows job
+# against a linux stemcell. This is a file that will cause a bash script to
+# immediately exit (such as when exporting a release) but be ignored when run
+# in powershell.


### PR DESCRIPTION
Signed-off-by: Leah Hanson <lhanson@pivotal.io>

**What this PR does / why we need it**:
Adds ops-files for controlling deployment name and kubo version.

When deploying multiple clusters on the same bosh director, it is necessary to give them different names and sometimes to specify different kubo versions for each one. These ops-files make it easier to change these settings because you can put the values in vars-files rather than changing the base manifest manually every time.

**How can this PR be verified?**
Use these opsfiles, see that you can create a deployment named something other than `cfcr` or with an arbitrary version.

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
