### PR TITLE
Remove bosh spec property `Labels` as it conflicts with k8s-args `node-labels` property.

### DIFF
--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -47,9 +47,6 @@ properties:
         docker-only: null
   no_proxy:
     description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
-  labels:
-    description: '<Warning: Alpha feature> Labels to add when registering the node
-      in the cluster.  Labels must be key=value pairs separated by '',''.'
   tls.kubelet:
     description: Certificate and private key for the Kubernetes worker
     parameters:

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -33,9 +33,6 @@ DATA_DIR=/var/vcap/store/kubernetes
   if iaas=="vsphere"
     labels << "failure-domain.beta.kubernetes.io/zone=#{spec.az}"
   end
-  if_p("labels") do |node_labels|
-    labels += node_labels.map {|k,v| "#{k}=#{v}"}
-  end
   labels = labels.join(',')
 %>
 
@@ -104,11 +101,19 @@ start_kubelet() {
   kubelet \
   <%-
     if_p('k8s-args') do |args|
+      node_labels = args.select { |f,_| f == 'node-labels' }
+      if node_labels.empty?
+        args['node-labels'] = labels
+      else
+        node_labels = "#{node_labels['node-labels']},#{labels}"
+      end
       args.each do |flag, value|
         valueString = ""
 
         if value.nil?
           # Do nothing to supports args-less flags (--example)
+        elsif flag == 'node-labels'
+          valueString = "=#{node_labels}" # << labels
         elsif value.is_a? Array
           valueString = "=#{value.join(",")}"
         elsif value.is_a? Hash
@@ -120,12 +125,15 @@ start_kubelet() {
     <%= "--#{flag}#{valueString}" %> \
   <%-
       end
-    end
+  end.else do
+  -%>
+    <%= "--node-labels=#{labels}" %> \
+  <%-
+  end
   -%>
     <% if include_config -%>--cloud-config=${cloud_config}<% end %> \
     <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> \
     --hostname-override=$(get_hostname_override) \
-    --node-labels=<%= labels %> \
     --config="/var/vcap/jobs/kubelet/config/kubeletconfig.yml" \
   1>> $LOG_DIR/kubelet.stdout.log \
   2>> $LOG_DIR/kubelet.stderr.log

--- a/spec/kubelet_ctl_spec.rb
+++ b/spec/kubelet_ctl_spec.rb
@@ -22,6 +22,18 @@ describe 'kubelet_ctl' do
     expect(rendered_template).to include(',bosh.id=fake-bosh-id')
   end
 
+  it 'labels the kubelet with custom labels' do
+    manifest_properties = {
+      'k8s-args' => {
+        'node-labels' => 'foo=bar,k8s.node=custom'
+      }
+    }
+    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    expect(rendered_kubelet_ctl).to include(',bosh.id=fake-bosh-id')
+    expect(rendered_kubelet_ctl).to include(',k8s.node=custom')
+    expect(rendered_kubelet_ctl).to include('foo=bar')
+  end
+
   it 'has no http proxy when no proxy is defined' do
     rendered_kubelet_ctl = compiled_template(
       'kubelet',


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
Remove confusion between k8s-args `node-labels` and bosh spec `Labels`. It is expected that we can use k8s-args to set flags for kubelet rather than using bosh spec flags. This PR preferences using k8s-args.

**How can this PR be verified?**
CI

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
Yes, will add PR to add integration test for Labels

**Does this affect upgrade, or is there any migration required?**
Yes, people who have used Labels in the past will need to move their custom labels to be
```yaml
k8s-args:
  node-labels: "comma delimited labels"
```

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Remove bosh spec property `Labels` as it conflicts with k8s-args `node-labels` property.
```
