### PR TITLE
Update coredns.yml.erb

### DIFF
--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -146,6 +146,11 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
       dnsPolicy: Default
       volumes:
         - name: config-volume


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds readiness probe for CoreDNS
https://github.com/kubernetes/kubernetes/pull/74137

**How can this PR be verified?**
It just works

**Is there any change in kubo-deployment?**
Nope

**Is there any change in kubo-ci?**
Nope

**Does this affect upgrade, or is there any migration required?**
Nope

**Which issue(s) this PR fixes:**
Nope

**Release note**:
```release-note
CoreDNS now has a readiness probe
```
