### PR TITLE
Update to use Windows 2019 docker images, add flannel/vxlan windows support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -98,18 +98,18 @@ kubernetes-1.13.3/kubelet:
   size: 113018904
   object_id: 7b17cc29-f681-4b19-5c95-ce6c52dc1608
   sha: 9b5d05229ba35aaed6476e7177e786c9b1fa87c0
-kubernetes-windows-1.12.5/kube-proxy.exe:
-  size: 49589248
-  object_id: 99d889a9-6a41-4bcc-7754-7f805af2f109
-  sha: eee0ff31a6fd908c83f727ad228a50b6ae8fd008
-kubernetes-windows-1.12.5/kubectl.exe:
-  size: 57638400
-  object_id: 4fa776d2-74e0-4110-429a-469d9094bed0
-  sha: c203b7181e3321511af4e378467c69c931d6bd29
-kubernetes-windows-1.12.5/kubelet.exe:
-  size: 160816128
-  object_id: f55f1065-0b8a-4273-48ae-cb58f292edea
-  sha: 6b872771cbfa278d829b178d23c1567820eeaf2b
+kubernetes-windows-1.13.3/kube-proxy.exe:
+  size: 34465792
+  object_id: cbbdeaed-e7f0-4c2a-77f2-3d51e923ae5d
+  sha: a745d26e07ddeaf8d7f39deda2d69a9fb30ea60f
+kubernetes-windows-1.13.3/kubectl.exe:
+  size: 39667712
+  object_id: a569d842-fcf3-4882-5661-e791c6b11189
+  sha: b039a81069305d4a45c41f6e921a054c758a338b
+kubernetes-windows-1.13.3/kubelet.exe:
+  size: 102758912
+  object_id: 4f51220c-30d8-4321-4127-9606f7cf61df
+  sha: 9725f4c0a04785369db063d1f96be0cb227453b5
 libmnl0_1.0.3-3.deb:
   size: 11416
   object_id: 245e085f-1ad2-447d-67bb-1894b960c571

--- a/jobs/flanneld-windows/spec
+++ b/jobs/flanneld-windows/spec
@@ -3,6 +3,7 @@ name: flanneld-windows
 
 templates:
   bin/flanneld_ctl.ps1.erb: bin/flanneld_ctl.ps1
+  bin/hns.psm1: bin/hns.psm1
   config/etcd-ca.crt.erb: config/etcd-ca.crt
   config/etcd-client.crt.erb: config/etcd-client.crt
   config/etcd-client.key.erb: config/etcd-client.key

--- a/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
+++ b/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
@@ -10,23 +10,23 @@ trap { $host.SetShouldExit(1) }
     end
   end
 -%>
-<%-
-  def get_network_name
-    if p("backend-type") == "win-overlay"
-      "vxlan0"
-    else
-      "cbr0"
-    end
-  end
--%>
+$networkType = "<%= p("backend-type") %>"
+
+function get_network_name {
+  if ($networkType -eq "win-overlay") {
+    return "flannel.4096"
+  } else {
+    return "cbr0"
+  }
+}
 
 function start_flanneld {
   <% etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",") %>
 
   mkdir -force /etc/cni/net.d
-  $confFile= '
+  $confFile= @"
 {
-  "name": "<%= get_network_name %>",
+  "name": "$(get_network_name)",
   "plugins": [
     {
       "type": "flannel",
@@ -71,9 +71,17 @@ function start_flanneld {
     }
   ]
 }
-'
+"@
   Set-Content -Path /etc/cni/net.d/50-flannel.conflist -Value $confFile
 
+  if (!(Get-HnsNetwork | ? Name -Eq "External")) {
+    ipmo /var/vcap/jobs/flanneld-windows/bin/hns.psm1
+    if ($networkType -eq "win-overlay") {
+      New-HNSNetwork -Type "Overlay" -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })  -Verbose
+    } else {
+      New-HNSNetwork -Type "L2Bridge" -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -Verbose
+    }
+  }
 
   /var/vcap/packages/flanneld-windows/flanneld.exe `
     --etcd-endpoints=<%= etcd_endpoints %> `

--- a/jobs/flanneld-windows/templates/bin/hns.psm1
+++ b/jobs/flanneld-windows/templates/bin/hns.psm1
@@ -1,0 +1,502 @@
+#########################################################################
+# Global Initialize
+function Get-VmComputeNativeMethods()
+{
+        $signature = @'
+                     [DllImport("vmcompute.dll")]
+                     public static extern void HNSCall([MarshalAs(UnmanagedType.LPWStr)] string method, [MarshalAs(UnmanagedType.LPWStr)] string path, [MarshalAs(UnmanagedType.LPWStr)] string request, [MarshalAs(UnmanagedType.LPWStr)] out string response);
+'@
+
+    # Compile into runtime type
+    Add-Type -MemberDefinition $signature -Namespace VmCompute.PrivatePInvoke -Name NativeMethods -PassThru
+}
+
+#########################################################################
+# Configuration
+#########################################################################
+function Get-HnsSwitchExtensions
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [string] $NetworkId
+    )
+
+    return (Get-HNSNetwork $NetworkId).Extensions
+}
+
+function Set-HnsSwitchExtension
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [string] $NetworkId,
+        [parameter(Mandatory=$true)] [string] $ExtensionId,
+        [parameter(Mandatory=$true)] [bool]   $state
+    )
+
+    # { "Extensions": [ { "Id": "...", "IsEnabled": true|false } ] }
+    $req = @{
+        "Extensions"=@(@{
+            "Id"=$ExtensionId;
+            "IsEnabled"=$state;
+        };)
+    }
+    Invoke-HNSRequest -Method POST -Type networks -Id $NetworkId -Data (ConvertTo-Json $req)
+}
+
+#########################################################################
+# Activities
+#########################################################################
+function Get-HNSActivities
+{
+    [cmdletbinding()]Param()
+    return Invoke-HNSRequest -Type activities -Method GET
+}
+
+#########################################################################
+# PolicyLists
+#########################################################################
+function Get-HNSPolicyList {
+    [cmdletbinding()]Param()
+    return Invoke-HNSRequest -Type policylists -Method GET
+}
+
+function Remove-HnsPolicyList
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory=$true,ValueFromPipeline=$True,ValueFromPipelinebyPropertyName=$True)]
+        [Object[]] $InputObjects
+    )
+    begin {$Objects = @()}
+    process {$Objects += $InputObjects; }
+    end {
+        $Objects | foreach {  Invoke-HNSRequest -Method DELETE -Type  policylists -Id $_.Id }
+    }
+}
+
+function New-HnsRoute {
+    param
+    (
+        [parameter(Mandatory = $false)] [Guid[]] $Endpoints = $null,
+        [parameter(Mandatory = $true)] [string] $DestinationPrefix,
+        [parameter(Mandatory = $false)] [switch] $EncapEnabled
+    )
+
+    $policyLists = @{
+        References = @(
+            get-endpointReferences $Endpoints;
+        );
+        Policies   = @(
+            @{
+                Type = "ROUTE";
+                DestinationPrefix = $DestinationPrefix;
+                NeedEncap = $EncapEnabled.IsPresent;
+            }
+        );
+    }
+
+    Invoke-HNSRequest -Method POST -Type policylists -Data (ConvertTo-Json  $policyLists -Depth 10)
+}
+
+function New-HnsLoadBalancer {
+    param
+    (
+        [parameter(Mandatory = $false)] [Guid[]] $Endpoints = $null,
+        [parameter(Mandatory = $true)] [int] $InternalPort,
+        [parameter(Mandatory = $true)] [int] $ExternalPort,
+        [parameter(Mandatory = $false)] [string] $Vip
+    )
+
+    $policyLists = @{
+        References = @(
+            get-endpointReferences $Endpoints;
+        );
+        Policies   = @(
+            @{
+                Type = "ELB";
+                InternalPort = $InternalPort;
+                ExternalPort = $ExternalPort;
+                VIPs = @($Vip);
+            }
+        );
+    }
+
+    Invoke-HNSRequest -Method POST -Type policylists -Data ( ConvertTo-Json  $policyLists -Depth 10)
+}
+
+
+function get-endpointReferences {
+    param
+    (
+        [parameter(Mandatory = $true)] [Guid[]] $Endpoints = $null
+    )
+    if ($Endpoints ) {
+        $endpointReference = @()
+        foreach ($endpoint in $Endpoints)
+        {
+            $endpointReference += "/endpoints/$endpoint"
+        }
+        return $endpointReference
+    }
+    return @()
+}
+
+#########################################################################
+# Networks
+#########################################################################
+function New-HnsNetwork
+{
+    param
+    (
+        [parameter(Mandatory=$false, Position=0)]
+        [string] $JsonString,
+        [ValidateSet('ICS', 'Internal', 'Transparent', 'NAT', 'Overlay', 'L2Bridge', 'L2Tunnel', 'Layered', 'Private')]
+        [parameter(Mandatory = $false, Position = 0)]
+        [string] $Type,
+        [parameter(Mandatory = $false)] [string] $Name,
+        [parameter(Mandatory = $false)] $AddressPrefix,
+        [parameter(Mandatory = $false)] $Gateway,
+        [HashTable[]][parameter(Mandatory=$false)] $SubnetPolicies, #  @(@{VSID = 4096; })
+
+        [parameter(Mandatory = $false)] [switch] $IPv6,
+        [parameter(Mandatory = $false)] [string] $DNSServer,
+        [parameter(Mandatory = $false)] [string] $AdapterName,
+        [HashTable][parameter(Mandatory=$false)] $AdditionalParams, #  @ {"ICSFlags" = 0; }
+        [HashTable][parameter(Mandatory=$false)] $NetworkSpecificParams #  @ {"InterfaceConstraint" = ""; }
+    )
+
+    Begin {
+        if (!$JsonString) {
+            $netobj = @{
+                Type          = $Type;
+            };
+
+            if ($Name) {
+                $netobj += @{
+                    Name = $Name;
+                }
+            }
+
+            # Coalesce prefix/gateway into subnet objects.
+            if ($AddressPrefix) {
+                $subnets += @()
+                $prefixes = @($AddressPrefix)
+                $gateways = @($Gateway)
+
+                $len = $prefixes.length
+                for ($i = 0; $i -lt $len; $i++) {
+                    $subnet = @{ AddressPrefix = $prefixes[$i]; }
+                    if ($i -lt $gateways.length -and $gateways[$i]) {
+                        $subnet += @{ GatewayAddress = $gateways[$i]; }
+
+                        if ($SubnetPolicies) {
+                            $subnet.Policies += $SubnetPolicies
+                        }
+                    }
+
+                    $subnets += $subnet
+                }
+
+                $netobj += @{ Subnets = $subnets }
+            }
+
+            if ($IPv6.IsPresent) {
+                $netobj += @{ IPv6 = $true }
+            }
+
+            if ($AdapterName) {
+                $netobj += @{ NetworkAdapterName = $AdapterName; }
+            }
+
+            if ($AdditionalParams) {
+                $netobj += @{
+                    AdditionalParams = @{}
+                }
+
+                foreach ($param in $AdditionalParams.Keys) {
+                    $netobj.AdditionalParams += @{
+                        $param = $AdditionalParams[$param];
+                    }
+                }
+            }
+
+            if ($NetworkSpecificParams) {
+                $netobj += $NetworkSpecificParams
+            }
+
+            $JsonString = ConvertTo-Json $netobj -Depth 10
+        }
+
+    }
+    Process{
+        return Invoke-HnsRequest -Method POST -Type networks -Data $JsonString
+    }
+}
+
+
+#########################################################################
+# Endpoints
+#########################################################################
+function New-HnsEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$false, Position = 0)] [string] $JsonString = $null,
+        [parameter(Mandatory = $false, Position = 0)] [Guid] $NetworkId,
+        [parameter(Mandatory = $false)] [string] $Name,
+        [parameter(Mandatory = $false)] [string] $IPAddress,
+        [parameter(Mandatory = $false)] [string] $Gateway,
+        [parameter(Mandatory = $false)] [string] $MacAddress,
+        [parameter(Mandatory = $false)] [switch] $EnableOutboundNat
+    )
+
+    begin
+    {
+        if ($JsonString)
+        {
+            $EndpointData = $JsonString | ConvertTo-Json | ConvertFrom-Json
+        }
+        else
+        {
+            $endpoint = @{
+                VirtualNetwork = $NetworkId;
+                Policies       = @();
+            }
+
+            if ($Name) {
+                $endpoint += @{
+                    Name = $Name;
+                }
+            }
+
+            if ($MacAddress) {
+                $endpoint += @{
+                    MacAddress     = $MacAddress;
+                }
+            }
+
+            if ($IPAddress) {
+                $endpoint += @{
+                    IPAddress      = $IPAddress;
+                }
+            }
+
+            if ($Gateway) {
+                $endpoint += @{
+                    GatewayAddress = $Gateway;
+                }
+            }
+
+            if ($EnableOutboundNat) {
+                $endpoint.Policies += @{
+                    Type = "OutBoundNAT";
+                }
+
+            }
+            # Try to Generate the data
+            $EndpointData = convertto-json $endpoint
+        }
+    }
+
+    Process
+    {
+        return Invoke-HNSRequest -Method POST -Type endpoints -Data $EndpointData
+    }
+}
+
+
+function New-HnsRemoteEndpoint
+{
+    param
+    (
+        [parameter(Mandatory = $true)] [Guid] $NetworkId,
+        [parameter(Mandatory = $false)] [string] $IPAddress,
+        [parameter(Mandatory = $false)] [string] $MacAddress
+    )
+
+    $remoteEndpoint = @{
+        ID = [Guid]::NewGuid();
+        VirtualNetwork = $NetworkId;
+        IPAddress = $IPAddress;
+        MacAddress = $MacAddress;
+        IsRemoteEndpoint = $true;
+    }
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $remoteEndpoint  -Depth 10)
+
+}
+
+
+function Attach-HnsHostEndpoint
+{
+    param
+    (
+     [parameter(Mandatory=$true)] [Guid] $EndpointID,
+     [parameter(Mandatory=$true)] [int] $CompartmentID
+     )
+    $request = @{
+        SystemType    = "Host";
+        CompartmentId = $CompartmentID;
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request) -Action "attach" -Id $EndpointID
+}
+
+function Attach-HNSVMEndpoint
+{
+    param
+    (
+     [parameter(Mandatory=$true)] [Guid] $EndpointID,
+     [parameter(Mandatory=$true)] [string] $VMNetworkAdapterName
+     )
+
+    $request = @{
+        VirtualNicName   = $VMNetworkAdapterName;
+        SystemType    = "VirtualMachine";
+    };
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request ) -Action "attach" -Id $EndpointID
+
+}
+
+function Attach-HNSEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [Guid] $EndpointID,
+        [parameter(Mandatory=$true)] [int] $CompartmentID,
+        [parameter(Mandatory=$true)] [string] $ContainerID
+    )
+     $request = @{
+        ContainerId = $ContainerID;
+        SystemType="Container";
+        CompartmentId = $CompartmentID;
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request) -Action "attach" -Id $EndpointID
+}
+
+function Detach-HNSVMEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [Guid] $EndpointID
+    )
+    $request = @{
+        SystemType  = "VirtualMachine";
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request ) -Action "detach" -Id $EndpointID
+}
+
+function Detach-HNSHostEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [Guid] $EndpointID
+    )
+    $request = @{
+        SystemType  = "Host";
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request ) -Action "detach" -Id $EndpointID
+}
+
+function Detach-HNSEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$true)] [Guid] $EndpointID,
+        [parameter(Mandatory=$true)] [string] $ContainerID
+    )
+
+    $request = @{
+        ContainerId = $ContainerID;
+        SystemType="Container";
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request ) -Action "detach" -Id $EndpointID
+}
+#########################################################################
+
+function Invoke-HNSRequest
+{
+    param
+    (
+        [ValidateSet('GET', 'POST', 'DELETE')]
+        [parameter(Mandatory=$true)] [string] $Method,
+        [ValidateSet('networks', 'endpoints', 'activities', 'policylists', 'endpointstats', 'plugins')]
+        [parameter(Mandatory=$true)] [string] $Type,
+        [parameter(Mandatory=$false)] [string] $Action = $null,
+        [parameter(Mandatory=$false)] [string] $Data = $null,
+        [parameter(Mandatory=$false)] [Guid] $Id = [Guid]::Empty
+    )
+
+    $hnsPath = "/$Type"
+
+    if ($id -ne [Guid]::Empty)
+    {
+        $hnsPath += "/$id";
+    }
+
+    if ($Action)
+    {
+        $hnsPath += "/$Action";
+    }
+
+    $request = "";
+    if ($Data)
+    {
+        $request = $Data
+    }
+
+    $output = "";
+    $response = "";
+    Write-Verbose "Invoke-HNSRequest Method[$Method] Path[$hnsPath] Data[$request]"
+
+    $hnsApi = Get-VmComputeNativeMethods
+    $hnsApi::HNSCall($Method, $hnsPath, "$request", [ref] $response);
+
+    Write-Verbose "Result : $response"
+    if ($response)
+    {
+        try {
+            $output = ($response | ConvertFrom-Json);
+        } catch {
+            Write-Error $_.Exception.Message
+            return ""
+        }
+        if ($output.Error)
+        {
+             Write-Error $output;
+        }
+        $output = $output.Output;
+    }
+
+    return $output;
+}
+
+#########################################################################
+
+Export-ModuleMember -Function Get-HNSActivities
+Export-ModuleMember -Function Get-HnsSwitchExtensions
+Export-ModuleMember -Function Set-HnsSwitchExtension
+
+Export-ModuleMember -Function New-HNSNetwork
+
+Export-ModuleMember -Function New-HNSEndpoint
+Export-ModuleMember -Function New-HnsRemoteEndpoint
+
+Export-ModuleMember -Function Attach-HNSHostEndpoint
+Export-ModuleMember -Function Attach-HNSVMEndpoint
+Export-ModuleMember -Function Attach-HNSEndpoint
+Export-ModuleMember -Function Detach-HNSHostEndpoint
+Export-ModuleMember -Function Detach-HNSVMEndpoint
+Export-ModuleMember -Function Detach-HNSEndpoint
+
+Export-ModuleMember -Function Get-HNSPolicyList
+Export-ModuleMember -Function Remove-HnsPolicyList
+Export-ModuleMember -Function New-HnsRoute
+Export-ModuleMember -Function New-HnsLoadBalancer
+
+Export-ModuleMember -Function Invoke-HNSRequest

--- a/jobs/flanneld/spec
+++ b/jobs/flanneld/spec
@@ -20,6 +20,12 @@ properties:
   backend-type:
     description: The network backend to use
     default: "vxlan"
+  vni:
+    description: VXLAN Identifier (VNI) to be used
+    default: 1
+  port:
+    description: UDP port to use for sending encapsulated packets
+    default: 8472
 
 consumes:
 - name: etcd

--- a/jobs/flanneld/templates/bin/flanneld_ctl.erb
+++ b/jobs/flanneld/templates/bin/flanneld_ctl.erb
@@ -72,7 +72,7 @@ EOL
     --cert-file /var/vcap/jobs/flanneld/config/etcd-client.crt \
     --key-file /var/vcap/jobs/flanneld/config/etcd-client.key \
     --ca-file /var/vcap/jobs/flanneld/config/etcd-ca.crt \
-    set /coreos.com/network/config '{"Network":"<%= p('pod-network-cidr') %>","Backend":{"Type": "<%= p('backend-type') %>"}}'
+    set /coreos.com/network/config '{"Network":"<%= p('pod-network-cidr') %>","Backend":{"Type": "<%= p('backend-type') %>", "VNI": <%= p('vni') %>, "Port": <%= p('port') %>}}'
 
   flanneld -etcd-endpoints=<%= etcd_endpoints %> \
     --ip-masq \

--- a/jobs/kube-proxy-windows/spec
+++ b/jobs/kube-proxy-windows/spec
@@ -36,3 +36,7 @@ properties:
           CPUManager: true
           DryRun: false
         cleanup: false
+
+consumes:
+- name: flanneld-windows
+  type: flanneld-windows

--- a/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
+++ b/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
@@ -1,4 +1,17 @@
+<%-
+  def hns_network_name
+    if link('flanneld-windows').p('backend-type') == "win-overlay"
+      "flannel.4096"
+    else
+      "cbr0"
+    end
+  end
+-%>
 trap { $host.SetShouldExit(1) }
+
+$hnsNetworkName = "<%= hns_network_name %>"
+$sourceVIPFile = "/var/vcap/data/kube-proxy-windows/sourceVip.json"
+$configFile = "/var/vcap/jobs/kube-proxy-windows/config/config.yml"
 
 function ensure_kubelet_is_running {
   curl.exe --fail http://localhost:10248/healthz
@@ -7,11 +20,37 @@ function ensure_kubelet_is_running {
   }
 }
 
-function start_kube_proxy {
-  $network = Get-HnsNetwork | ? Type -Eq L2Bridge
-  $env:KUBE_NETWORK = $network.Name
+function set_source_vip {
+  if (!(Test-Path $sourceVIPFile)) {
+    $network = Get-HnsNetwork | ? Name -Eq $hnsNetworkName
+    $subnet = $network.Subnets[0].AddressPrefix
+    $ipamConfig = @"
+{"cniVersion": "0.2.0", "name": "$hnsNetworkName", "ipam":{"type":"host-local","ranges":[[{"subnet":"$subnet"}]],"dataDir":"/var/lib/cni/networks"}}
+"@
+    $env:CNI_COMMAND="ADD"
+    $env:CNI_CONTAINERID="dummy"
+    $env:CNI_NETNS="dummy"
+    $env:CNI_IFNAME="dummy"
+    $env:CNI_PATH="/var/vcap/packages/cni-windows/bin"
 
-  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
+    echo $ipamConfig | /var/vcap/packages/cni-windows/bin/host-local.exe > $sourceVIPFile
+  }
+
+  if (!(Select-String -Path $configFile -Pattern "sourceVip")) {
+    $vip = (Get-Content $sourceVIPFile | ConvertFrom-Json).ip4.ip.Split("/")[0]
+    $config = @"
+winkernel:
+  sourceVip: $vip
+"@
+    Add-Content -Path $configFile -Value $config
+  }
+}
+
+function start_kube_proxy {
+  $env:KUBE_NETWORK = $hnsNetworkName
+
+  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 `
+  --config $configFile
 }
 
 function check_for_networking {
@@ -45,6 +84,7 @@ function misc_setup {
 function main() {
   misc_setup
   check_for_networking
+  set_source_vip
   start_kube_proxy
 }
 

--- a/jobs/kube-proxy-windows/templates/config/config.yml.erb
+++ b/jobs/kube-proxy-windows/templates/config/config.yml.erb
@@ -11,3 +11,7 @@
 %>
 <% require 'yaml' %><%= p('kube-proxy-configuration').to_yaml %>
 hostnameOverride: <%= hostname %>
+<% if link('flanneld-windows').p('backend-type') == "win-overlay" %>
+featureGates:
+  WinOverlay: true
+<% end %>

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -124,12 +124,13 @@ function load_base_images {
   }
 
   docker pull mcr.microsoft.com/windows/nanoserver:1809
-  docker pull mcr.microsoft.com/windows/servercore:ltsc2019
-
   docker tag (docker images mcr.microsoft.com/windows/nanoserver:1809 -q) mcr.microsoft.com/windows/nanoserver
-  docker tag (docker images mcr.microsoft.com/windows/servercore:ltsc2019 -q) mcr.microsoft.com/windows/servercore
-
   docker build -t kubeletwin/pause /var/vcap/jobs/kubelet-windows/config
+
+  Start-Job -ScriptBlock {
+    docker pull mcr.microsoft.com/windows/servercore:ltsc2019
+    docker tag (docker images mcr.microsoft.com/windows/servercore:ltsc2019 -q) mcr.microsoft.com/windows/servercore
+  }
 }
 
 function set_acls {

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -70,6 +70,7 @@ function start_kubelet {
       end
     end
   -%>
+  mkdir -force C:\tmp # workaround for conformance tests
 
   /var/vcap/packages/kubernetes-windows/bin/kubelet `
   <%-
@@ -138,12 +139,20 @@ function load_base_images {
   docker build -t kubeletwin/pause /var/vcap/jobs/kubelet-windows/config
 }
 
+function set_acls {
+  $ar = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Users", "ReadAndExecute,CreateFiles,AppendData", "ContainerInherit, ObjectInherit", "None", "Allow")
+  $acl = Get-Acl C:\var
+  $acl.SetAccessRule($ar)
+  Set-Acl C:\var $acl
+}
+
 function main {
   delete_stale_drained_node
   check_for_networking
   ensure_docker_is_running
   ensure_kubeproxy_is_running
   load_base_images
+  set_acls
   start_kubelet
 }
 

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -116,13 +116,6 @@ function ensure_kubeproxy_is_running {
   }
 }
 
-function ensure_docker_is_running {
-  curl.exe --fail http://localhost:10256/healthz
-  if (-not $?) {
-    throw "kube-proxy is not available"
-  }
-}
-
 function load_base_images {
   # Temporary workaround until we bring our own images
   docker version
@@ -149,8 +142,7 @@ function set_acls {
 function main {
   delete_stale_drained_node
   check_for_networking
-  ensure_docker_is_running
-  ensure_kubeproxy_is_running
+  #ensure_kubeproxy_is_running
   load_base_images
   set_acls
   start_kubelet

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -128,25 +128,14 @@ function load_base_images {
   if (-not $?) {
     throw "docker is not available"
   }
-  docker pull mcr.microsoft.com/windows/nanoserver:1803
-  docker pull mcr.microsoft.com/windows/servercore:1803
 
-  if (!(docker images mcr.microsoft.com/windows/nanoserver:latest -q))
-  {
-    docker tag (docker images mcr.microsoft.com/windows/nanoserver -q) mcr.microsoft.com/windows/nanoserver
-  }
+  docker pull mcr.microsoft.com/windows/nanoserver:1809
+  docker pull mcr.microsoft.com/windows/servercore:ltsc2019
 
-  if (!(docker images mcr.microsoft.com/windows/servercore:latest -q))
-  {
-    docker tag (docker images mcr.microsoft.com/windows/servercore -q) mcr.microsoft.com/windows/servercore
-  }
+  docker tag (docker images mcr.microsoft.com/windows/nanoserver:1809 -q) mcr.microsoft.com/windows/nanoserver
+  docker tag (docker images mcr.microsoft.com/windows/servercore:ltsc2019 -q) mcr.microsoft.com/windows/servercore
 
-  $infraPodImage=docker images kubeletwin/pause -q
-  if (!$infraPodImage)
-  {
-    cd /var/vcap/jobs/kubelet-windows/config
-    docker build -t kubeletwin/pause .
-  }
+  docker build -t kubeletwin/pause /var/vcap/jobs/kubelet-windows/config
 }
 
 function main {

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -3,7 +3,7 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$KUBERNETES_VERSION="1.12.5"
+$KUBERNETES_VERSION="1.13.3"
 
 New-Item -Path "${env:BOSH_INSTALL_TARGET}" -Name "bin" -ItemType "directory"
 

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -2,5 +2,5 @@
 name: kubernetes-windows
 
 files:
-- kubernetes-windows-1.12.5/*
+- kubernetes-windows-1.13.3/*
 - exiter.ps1


### PR DESCRIPTION
**What this PR does / why we need it**:

1. **Switch to 2019 images.** This makes kubo-release compatible with kubo-deployment [after this matching PR](https://github.com/cloudfoundry-incubator/kubo-deployment/pull/385).

2. **Update kubernetes-windows binaries to 1.13.3** to match linux binaries.

3. **Alter windows file permissions** to make conformance test suite pass.

4. **Download windows/servercore image in background** to allow windows nodes to start faster.

5. **Add support for overlay networking in windows clusters.** This adjusts the windows config/ctl scripts to handle the different settings required for vxlan, and **adds VNI and Port settings to the linux flanneld_ctl** because the non-configurable windows defaults need to be set in the etcd config. These settings are passed in by the ops-file `windows/use_overlay` provided in the [kubo-deployment PR](https://github.com/cloudfoundry-incubator/kubo-deployment/pull/385).

**How can this PR be verified?**
Deploy with windows2019 stemcell & kubo-deployment changes.

**Is there any change in kubo-deployment?**
https://github.com/cloudfoundry-incubator/kubo-deployment/pull/385

**Is there any change in kubo-ci?**
Needs to use windows2019 stemcell.

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**
Need to move to windows2019 because that is what GA windows support in kubernetes 1.14 will official support.

**Release note**:
Covered by prior "adds windows support" release note.
```release-note
NONE
```
