### PR TITLE
Use k8s-args.root-dir in drain script when watching for PVC detach

### DIFF
--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -45,7 +45,10 @@ drain_node() {
 }
 
 get_k8s_disks() {
-  disks=$(lsblk -dnl -o NAME,TYPE,MOUNTPOINT | awk '/var\/lib\/kubelet/ {print $1}')
+<%-
+  root_dir = p('k8s-args', {}).fetch('root-dir', "/var/lib/kubelet").gsub("/", "\\/")
+-%>
+  disks=$(lsblk -dnl -o NAME,TYPE,MOUNTPOINT | awk '/<%= root_dir %>/ {print $1}')
   echo ${disks[@]} | tr " " "|"
 }
 

--- a/spec/kubelet_drain_spec.rb
+++ b/spec/kubelet_drain_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+
+def get_k8s_disks_dir(rendered_drain)
+  lsblk_line = rendered_drain.split("\n").select { |line| line[/MOUNTPOINT/i] }
+  expect(lsblk_line.length).to be(1)
+  lsblk_line[0].match(/awk '\/(.+)\/ {print \$1}'/).captures[0]
+end
+
+describe 'kubelet drain' do
+
+  it 'substitutes in the k8s-args.root-dir property for get_k8s_disks()' do
+    manifest_properties = {
+      'k8s-args' => {
+        'root-dir' => '/var/vcap/data/kubelet'
+      }
+    }
+
+    rendered_drain = compiled_template('kubelet', 'bin/drain', manifest_properties, {}, {}, nil, nil, nil)
+    k8s_disks_dir = get_k8s_disks_dir(rendered_drain)
+    expect(k8s_disks_dir).to eq(manifest_properties['k8s-args']['root-dir'].gsub("/", "\\/"))
+  end
+
+  it 'uses /var/lib/kubelet for get_k8s_disks() by default' do
+    rendered_drain = compiled_template('kubelet', 'bin/drain', {}, {}, {}, nil, nil, nil)
+    k8s_disks_dir = get_k8s_disks_dir(rendered_drain)
+    expect(k8s_disks_dir).to eq("/var/lib/kubelet".gsub("/", "\\/"))
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
If `root-dir` gets set then PVCs are mounted in a different location than `/var/lib/kubelet`. The piece of drain script that monitors for PVCs to be fully detached during a drain needs the monitor the correct location.

**How can this PR be verified?**
The spec test performs some verification. There is also an edge-case that we regularly hit on AWS where the EBS volume doesn't get fully detached during the Turbulence suite and it leads to the `StatefulSet` not restarting successfully. https://ci.kubo.sh/teams/main/pipelines/aws_vanilla_turbulence/jobs/run-tests/builds/36 is one such instance.

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
None.