### PR TITLE
Ensure the root filesystem is rshared for certain hostPath mounts

### DIFF
--- a/jobs/kubernetes-dependencies/templates/bin/pre-start.erb
+++ b/jobs/kubernetes-dependencies/templates/bin/pre-start.erb
@@ -2,6 +2,9 @@
 
 set -euxo pipefail
 
+# remount root as rshared for issue #309
+mount --make-rshared /
+
 CONNTRACK_PACKAGES=/var/vcap/packages/conntrack
 IPSET_PACKAGES=/var/vcap/packages/ipset
 NFS_PACKAGES=/var/vcap/packages/nfs


### PR DESCRIPTION

**What this PR does / why we need it**:
Enables `hostPath` volumes to work when the path is in the root filesystem.

It uses the only generic pre-start script in the release, likely the most logical place for this command at the moment.

**How can this PR be verified?**
Deploy a pod with a `hostPath` volume mounting `/var/lib/kubelet`.  With this patch it will succeed.  Without this patch it will fail per #309.  

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No, beyond potentially introducing functional tests for this case.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
#309 

**Release note**:
* Allows `hostPath` volumes to successfully attach to directories in the worker root filesystem.
```release-note

```