### PR TITLE
Allow customization of vxlan VNI and port

### DIFF
--- a/jobs/flanneld/spec
+++ b/jobs/flanneld/spec
@@ -26,6 +26,10 @@ properties:
     description: Certificate for etcdctl client authentication
   tls.etcdctl.private_key:
     description: Private key for etcdctl client authentication
+  vni:
+    description: VXLAN Identifier (VNI) to be used
+  port:
+    description: UDP port to use for sending encapsulated packets
 
 consumes:
 - name: etcd

--- a/jobs/flanneld/templates/bin/flanneld_ctl.erb
+++ b/jobs/flanneld/templates/bin/flanneld_ctl.erb
@@ -66,13 +66,17 @@ start_flanneld() {
 }
 EOL
 
-
+  <%
+    network_conf = {'Network' => p('pod-network-cidr'), 'Backend' => {'Type':  p('backend-type')}}
+    if_p('port') { |port| network_conf['Backend']['Port'] = port }
+    if_p('vni') { |vni| network_conf['Backend']['VNI'] = vni }
+  %>
   /var/vcap/packages/etcdctl/etcdctl \
     --endpoints <%= etcd_endpoints %> \
     --cert-file /var/vcap/jobs/flanneld/config/etcd-client.crt \
     --key-file /var/vcap/jobs/flanneld/config/etcd-client.key \
     --ca-file /var/vcap/jobs/flanneld/config/etcd-ca.crt \
-    set /coreos.com/network/config '{"Network":"<%= p('pod-network-cidr') %>","Backend":{"Type": "<%= p('backend-type') %>"}}'
+    set /coreos.com/network/config '<%= JSON.dump(network_conf) %>'
 
   flanneld -etcd-endpoints=<%= etcd_endpoints %> \
     --ip-masq \


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to override the VNI and port that Flannel will use for setting up the vxlan device. Windows currently only supports VNIs >= 4096, and the port must be 4789 (documented on [Flannel's docs](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#vxlan)).

**How can this PR be verified?**
- Deploy CFCR with https://github.com/pivotal-k8s/kubo-deployment/blob/55811bbaf131461966cd7db4c9e52354f463e36c/manifests/ops-files/windows/use-overlay.yml
- SSH onto any of the VMs, run `ip -d link show flannel.4096`
- See that the OS reports the `vxlan id` is equal to the VNI (4096), and the `dstport` is equal to the port (4789).

```
3: flannel.4096: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UNKNOWN mode DEFAULT group default
    link/ether 1a:46:34:d3:fa:0d brd ff:ff:ff:ff:ff:ff promiscuity 0
    vxlan id 4096 local 10.0.1.1 dev eth0 srcport 0 0 dstport 4789 nolearning ageing 300 udpcsum
```

**Is there any change in kubo-deployment?**
Yes

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No


**Release note**:
```release-note
Parameterized the VNI and port that vxlan devices will be configured to use when using Flannel in vxlan mode.
```
