### PR TITLE
Clarify load balancer healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A [BOSH](http://bosh.io/) release for [Kubernetes](http://kubernetes.io).  Forme
   - **Single Master:** Set up a DNS name pointing to your master's IP address
   - **Multiple Masters:** A TCP load balancer for your master nodes.
     - Use a TCP load balancer configured to connect to the master nodes on port 8443.
-    - Add healthchecks using either a TCP dial or HTTP by looking for a `200 OK` response from `/healthz`.
+    - Add healthchecks using either a TCP dial or HTTPS by looking for a `200 OK` response from `/healthz`.
     - if you have used [BOSH Bootloader](https://github.com/cloudfoundry/bosh-bootloader) on GCP then you need to manually create a firewall rule.  Allow access to port TCP 8443 to VMs in your BBL network tagged `cfcr-master` from your load balancer's IP.
 - Cloud Config with
   - `vm_types` named `minimal`, `small`, and `small-highmem` (See [cf-deployment](https://github.com/cloudfoundry/cf-deployment) for reference)


### PR DESCRIPTION

**What this PR does / why we need it**:
Setting up the AWS load balancer healthchecks is confusing (and easy to do incorrectly) with the current instructions. They should be using HTTPS, but before this PR the instructions say HTTP.

**How can this PR be verified?**
Reading it.

**Is there any change in kubo-deployment?**
No.

**Is there any change in kubo-ci?**
No.

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
N/A

**Release note**:
```release-note
NONE
```

Co-authored-by: @dpb587-pivotal
