### PR TITLE
Kubelet force drain

### DIFF
--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -39,6 +39,21 @@ properties:
   kubectl-drain-timeout:
     description: "The length of time to wait before giving up draining a node, zero means infinite"
     default: "0s"
+  kubectl-pod-shutdown-grace-period:
+    description: "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used."
+    default: "10"
+  kubectl-force-drain:
+    description: "Continue drain even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet."
+    default: true
+  kubectl-force-drain-daemonset:
+    description: "Ignore DaemonSet-managed pods during drain"
+    default: true
+  kubectl-delete-local-data:
+    description: "Continue drain even if there are pods using emptyDir (local data that will be deleted when the node is drained)"
+    default: true
+  force-drain:
+    description: "Forcibly terminate pods if all the pods fail to drain before the timeout."
+    default: false
   k8s-args:
     description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
     example: |

--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -39,21 +39,21 @@ properties:
   kubectl-drain-timeout:
     description: "The length of time to wait before giving up draining a node, zero means infinite"
     default: "0s"
-  kubectl-pod-shutdown-grace-period:
+  kubelet-drain-grace-period:
     description: "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used."
     default: "10"
-  kubectl-force-drain:
+  kubelet-drain-force:
     description: "Continue drain even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet."
     default: true
-  kubectl-force-drain-daemonset:
+  kubelet-drain-ignore-daemonsets:
     description: "Ignore DaemonSet-managed pods during drain"
     default: true
-  kubectl-delete-local-data:
+  kubelet-drain-delete-local-data:
     description: "Continue drain even if there are pods using emptyDir (local data that will be deleted when the node is drained)"
     default: true
-  force-drain:
+  kubelet-drain-force-node:
     description: "Forcibly terminate pods if all the pods fail to drain before the timeout."
-    default: true
+    default: false
   k8s-args:
     description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
     example: |

--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -53,7 +53,7 @@ properties:
     default: true
   force-drain:
     description: "Forcibly terminate pods if all the pods fail to drain before the timeout."
-    default: false
+    default: true
   k8s-args:
     description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
     example: |

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -74,14 +74,14 @@ drain_node() {
 
 force_kill_pods() {
   echo "Forcefully draining the node"
-  node_name=$(kubectl  get node -l "bosh.id=<%= spec.id %>" -o jsonpath="{.items[:].metadata.name}")
-  namespaces=( $(kubectl get pods --all-namespaces --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.namespace}" | xargs -n1 | sort -u -) )
+  node_name=$(kubectl --kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain get node -l "bosh.id=<%= spec.id %>" -o jsonpath="{.items[:].metadata.name}")
+  namespaces=( $(kubectl --kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain get pods --all-namespaces --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.namespace}" | xargs -n1 | sort -u -) )
   for namespace in "${namespaces[@]}"; do
     echo $namespace;
-    podnames=( $(kubectl get pods -n=${namespace} --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.name}") )
+    podnames=( $(kubectl --kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain get pods -n=${namespace} --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.name}") )
     for pod_name in "${podnames[@]}"; do
       echo "Force Deleting pod ${pod_name}"
-      kubectl delete pods ${pod_name}  --namespace ${namespace} --grace-period=0 --force
+      kubectl --kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain delete pods ${pod_name}  --namespace ${namespace} --grace-period=0 --force
     done
   done
 }

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -22,19 +22,9 @@ main() {
   k8s_disks=$(get_k8s_disks)
   echo "Mounted volumes: $k8s_disks"
   if ! drain_node ; then
-    <% if_p("force-drain") do |prop| %>
+    <% if_p("kubelet-drain-force-node") do |prop| %>
       <% if prop %>
-        echo "Forcefully draining the node"
-        node_name=$(kubectl  get node -l "bosh.id=<%= spec.id %>" -o jsonpath="{.items[:].metadata.name}")
-        namespaces=( $(kubectl get pods --all-namespaces --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.namespace}" | xargs -n1 | sort -u -) )
-        for namespace in "${namespaces[@]}"; do
-           echo $namespace;
-           podnames=( $(kubectl get pods -n=${namespace} --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.name}") )
-           for pod_name in "${podnames[@]}"; do
-            echo "Force Deleting pod ${pod_name}"
-            kubectl delete pods ${pod_name}  --namespace ${namespace} --grace-period=0 --force
-           done
-        done
+        force_kill_pods
       <% else %>
         echo "Unsuccessful function drain_node"
         exit 1
@@ -58,28 +48,42 @@ drain_node() {
   kubectl_args=()
   kubectl_args+=(--kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain drain)
   kubectl_args+=(-l "bosh.id=<%= spec.id %>")
-  kubectl_args+=(--grace-period <%= p("kubectl-pod-shutdown-grace-period") %>)
+  kubectl_args+=(--grace-period <%= p("kubelet-drain-grace-period") %>)
   kubectl_args+=(--timeout <%= p("kubectl-drain-timeout") %>)
 
-  <% if_p("kubectl-force-drain") do |prop| %>
+  <% if_p("kubelet-drain-force") do |prop| %>
     <% if prop %>
       kubectl_args+=(--force)
     <% end %>
   <% end %>
 
-  <% if_p("kubectl-force-drain-daemonset") do |prop| %>
+  <% if_p("kubelet-drain-ignore-daemonsets") do |prop| %>
     <% if prop %>
       kubectl_args+=(--ignore-daemonsets)
     <% end %>
   <% end %>
 
-  <% if_p("kubectl-delete-local-data") do |prop| %>
+  <% if_p("kubelet-drain-delete-local-data") do |prop| %>
     <% if prop %>
       kubectl_args+=(--delete-local-data)
     <% end %>
   <% end %>
 
   kubectl "${kubectl_args[@]}"
+}
+
+force_kill_pods() {
+  echo "Forcefully draining the node"
+  node_name=$(kubectl  get node -l "bosh.id=<%= spec.id %>" -o jsonpath="{.items[:].metadata.name}")
+  namespaces=( $(kubectl get pods --all-namespaces --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.namespace}" | xargs -n1 | sort -u -) )
+  for namespace in "${namespaces[@]}"; do
+    echo $namespace;
+    podnames=( $(kubectl get pods -n=${namespace} --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.name}") )
+    for pod_name in "${podnames[@]}"; do
+      echo "Force Deleting pod ${pod_name}"
+      kubectl delete pods ${pod_name}  --namespace ${namespace} --grace-period=0 --force
+    done
+  done
 }
 
 get_k8s_disks() {

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -35,13 +35,31 @@ cordon_node() {
 }
 
 drain_node() {
-  kubectl --kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain drain \
-    -l "bosh.id=<%= spec.id %>" \
-    --grace-period 10 \
-    --force \
-    --delete-local-data \
-    --ignore-daemonsets \
-    --timeout <%= p("kubectl-drain-timeout") %>
+  kubectl_args=()
+  kubectl_args+=(--kubeconfig /var/vcap/jobs/kubelet/config/kubeconfig-drain drain)
+  kubectl_args+=(-l "bosh.id=<%= spec.id %>")
+  kubectl_args+=(--grace-period <%= p("kubectl-pod-shutdown-grace-period") %>)
+  kubectl_args+=(--timeout <%= p("kubectl-drain-timeout") %>)
+
+  <% if_p("kubectl-force-drain") do |prop| %>
+    <% if prop %>
+      kubectl_args+=(--force)
+    <% end %>
+  <% end %>
+
+  <% if_p("kubectl-force-drain-daemonset") do |prop| %>
+    <% if prop %>
+      kubectl_args+=(--ignore-daemonsets)
+    <% end %>
+  <% end %>
+
+  <% if_p("kubectl-delete-local-data") do |prop| %>
+    <% if prop %>
+      kubectl_args+=(--delete-local-data)
+    <% end %>
+  <% end %>
+
+  kubectl "${kubectl_args[@]}"
 }
 
 get_k8s_disks() {

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -21,7 +21,27 @@ main() {
   retry cordon_node
   k8s_disks=$(get_k8s_disks)
   echo "Mounted volumes: $k8s_disks"
-  retry drain_node
+  if ! drain_node ; then
+    <% if_p("force-drain") do |prop| %>
+      <% if prop %>
+        echo "Forcefully draining the node"
+        node_name=$(kubectl  get node -l "bosh.id=<%= spec.id %>" -o jsonpath="{.items[:].metadata.name}")
+        namespaces=( $(kubectl get pods --all-namespaces --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.namespace}" | xargs -n1 | sort -u -) )
+        for namespace in "${namespaces[@]}"; do
+           echo $namespace;
+           podnames=( $(kubectl get pods -n=${namespace} --field-selector spec.nodeName=${node_name} -o jsonpath="{.items[:].metadata.name}") )
+           for pod_name in "${podnames[@]}"; do
+            echo "Force Deleting pod ${pod_name}"
+            kubectl delete pods ${pod_name}  --namespace ${namespace} --grace-period=0 --force
+           done
+        done
+      <% else %>
+        echo "Unsuccessful function drain_node"
+        exit 1
+      <% end %>
+    <% end %>
+  fi
+
   if [[ -z "${k8s_disks}" ]]; then
     echo "No attached PVs"
   else


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the kubelet drain properties configurable and also add a new job property to force kill pods if the node drain fails.

**How can this PR be verified?**
Set the job property "kubelet-drain-force-node" to true and drain the node with a PDB protected workload running on it.

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
There will be changes made to the kubo-ci.

**Does this affect upgrade, or is there any migration required?**
No

