### PR TITLE
fix issue #328

### DIFF
--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -45,10 +45,14 @@ processes:
     end
   %>
   - --apiserver-count=<%= link('kube-apiserver').instances.size %>
-  <% if_link('cloud-provider') do |cloud_provider| %>
-  - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
-  - --cloud-config=/var/vcap/jobs/kube-apiserver/config/cloud-provider.ini
-  <% end %>
+  <%- if_link('cloud-provider') do |cloud_provider| -%>
+  <% if "external".eql? cloud_provider.p('cloud-provider.type') %>
+   - --cloud-config=/var/vcap/jobs/kube-apiserver/config/cloud-provider.ini
+  <% else %>
+   - --cloud-provider=cloud_provider.p('cloud-provider.type')
+   - --cloud-config=/var/vcap/jobs/kube-apiserver/config/cloud-provider.ini
+   <% end  %>
+  <%- end -%>
   <% if !etcd_servers_property_set %>
   - --etcd-servers=<%= etcd_endpoints %>
   <% end %>

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -24,8 +24,12 @@ processes:
     end
   %>
   <%- if_link('cloud-provider') do |cloud_provider| -%>
-  - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
+  <% if "external".eql? cloud_provider.p('cloud-provider.type') %>
   - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
+  <% else %>
+  - --cloud-provider=cloud_provider.p('cloud-provider.type') 
+  - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
+ <% end %>
   <%- end -%>
   hooks:
     pre_start: /var/vcap/jobs/kube-controller-manager/bin/chmod-product-serial


### PR DESCRIPTION
**What this PR does / why we need it**:
In futur version of K8S the cloudprovider need to be external as in tree cloudprovider will be removed.

**How can this PR be verified?**
use external as cloudprovider

**Is there any change in kubo-deployment?**
no

**Is there any change in kubo-ci?**
no

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**
- fix issue #328 

**Release note**:
