### PR TITLE
Update deployment api versions

### DIFF
--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -71,7 +71,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/jobs/apply-specs/templates/specs/metrics-server/metrics-server-deployment.yml
+++ b/jobs/apply-specs/templates/specs/metrics-server/metrics-server-deployment.yml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server


### PR DESCRIPTION
**What this PR does / why we need it**:
`extensions/v1beta1` has been removed in https://github.com/kubernetes/kubernetes/pull/70672

**How can this PR be verified?**
Deploy edge kubernetes, see that it fails without these changes. Error will be:

```
1          Deploying /var/vcap/jobs/apply-specs/specs/coredns.yml               error: unable to recognize "/var/vcap/jobs/apply-specs/specs/coredns.yml": no matches for kind "Deployment" in version "extensions/v1beta1"  
```

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
I don't think so

**Release note**:
```release-note
Deployment specs were updated to apiVersion apps/v1
```
