### PR TITLE
Update the ruby Gemfile.lock to use bundler 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,39 +2,37 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    bosh-template (2.2.0)
+    bosh-template (2.2.1)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.3)
-    jaro_winkler (1.5.2)
-    parallel (1.13.0)
-    parser (2.6.0.0)
+    jaro_winkler (1.5.3)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    powerpack (0.1.2)
     rainbow (3.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    rubocop (0.63.0)
+    rspec-support (3.8.2)
+    rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     semi_semantic (1.2.0)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -45,4 +43,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Signed-off-by: Larry Hamel <lhamel@pivotal.io>

**What this PR does / why we need it**:
The docker image was updated to use bundler 2.0.2. This change aligns our lockfile with that new version.

**How can this PR be verified?**
n/a (pipeline runs)

**Is there any change in kubo-deployment?**
yes, but only to fix the same gemfile issue
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**
broken pipeline
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
N/A
```
