### PR TITLE
Fix up a broken version in coredns spec

### DIFF
--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -102,7 +102,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:011
+        image: coredns/coredns:1.5.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the coredns image version in the coredns spec. This version was not properly updated by the bump k8s pipeline because of the previous error that consumed the wrong coredns version.

**How can this PR be verified?**
The pipeline works.
**Is there any change in kubo-deployment?**
No
**Is there any change in kubo-ci?**
No
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**
n/a
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
