### PR TITLE
Merge kubo-release-windows back into this repo

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -130,3 +130,24 @@ talloc-2.1.9.tar.gz:
   size: 440335
   object_id: f2d8d5e1-1cb6-450c-480f-015534a76b17
   sha: e1e79fec4c0b6bd92be904a9c03b0a168478711a
+
+cni/cni-plugins-windows-amd64-c74e0e996.tgz:
+  size: 9678154
+  object_id: da0e8048-675b-4701-68e9-7db89e88723b
+  sha: 02c4d67a17a28c26cc471e56bf01dcacd104b346
+flannel-v0.11.0-windows-amd64.tar.gz:
+  size: 9488010
+  object_id: 968eac5f-3008-4bcf-5481-f3f4179162d4
+  sha: 71cb61a487c40df8eeb4d2bd68d7e891b51b44bb
+kubernetes-windows-1.14.4/kube-proxy.exe:
+  size: 39763456
+  object_id: 5f8542b1-f37b-44b7-760a-dc743f74cbb6
+  sha: 202b0e02ce4bade293f774561e12beec35f382f4
+kubernetes-windows-1.14.4/kubectl.exe:
+  size: 43554816
+  object_id: dbba0d4e-8424-48d5-7be0-a1a81f12d712
+  sha: 1c75cba2a91bdbbfb99eb76b6875d8afd6c6e6fd
+kubernetes-windows-1.14.4/kubelet.exe:
+  size: 116712448
+  object_id: a626b53f-363c-433c-5707-e9e29f0a40fc
+  sha: 2276450df26a2749e2ff39c60079723edb3b1eb2

--- a/jobs/flanneld-windows/monit
+++ b/jobs/flanneld-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "flanneld",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\flanneld-windows\\bin\\flanneld_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/flanneld-windows/spec
+++ b/jobs/flanneld-windows/spec
@@ -1,0 +1,36 @@
+---
+name: flanneld-windows
+
+templates:
+  bin/flanneld_ctl.ps1.erb: bin/flanneld_ctl.ps1
+  config/etcd-ca.crt.erb: config/etcd-ca.crt
+  config/etcd-client.crt.erb: config/etcd-client.crt
+  config/etcd-client.key.erb: config/etcd-client.key
+
+packages:
+- flanneld-windows
+- cni-windows
+
+properties:
+  pod-network-cidr:
+    description: The pod networking cidr for pod network overlay
+    default: "10.200.0.0/16"
+  backend-type:
+    description: The network backend to use
+    default: "win-overlay"
+  tls.etcdctl.ca:
+    description: CA for etcdctl client authentication
+  tls.etcdctl.certificate:
+    description: Certificate for etcdctl client authentication
+  tls.etcdctl.private_key:
+    description: Private key for etcdctl client authentication
+
+consumes:
+- name: etcd
+  type: etcd
+
+provides:
+- name: flanneld-windows
+  type: flanneld-windows
+  properties:
+  - backend-type

--- a/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
+++ b/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
@@ -1,0 +1,86 @@
+trap { $host.SetShouldExit(1) }
+
+<%-
+  def get_url(server, port)
+    if link('etcd').p('etcd.dns_suffix', false) != false
+      node_name = "#{server.name.gsub('_','-')}-#{server.index}"
+      return "https://#{node_name}.#{link('etcd').p('etcd.dns_suffix')}:#{port}"
+    else
+      return "https://#{server.address}:#{port}"
+    end
+  end
+-%>
+<%-
+  def get_network_name
+    if p("backend-type") == "win-overlay"
+      "vxlan0"
+    else
+      "cbr0"
+    end
+  end
+-%>
+
+function start_flanneld {
+  <% etcd_endpoints = link('etcd').instances.map { |server| get_url(server, 2379) }.join(",") %>
+
+  mkdir -force /etc/cni/net.d
+  $confFile= '
+{
+  "name": "<%= get_network_name %>",
+  "plugins": [
+    {
+      "type": "flannel",
+      "delegate": {
+        "hairpinMode": true,
+        "isDefaultGateway": true,
+        "type": "<%= p('backend-type') %>",
+        "dns": {
+          "nameservers": ["10.100.200.10"],
+          "search": ["svc.cluster.local"]
+        },
+        "policies": [
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "OutBoundNAT",
+              "ExceptionList": [
+                "<%= p('pod-network-cidr') %>",
+                "10.100.200.0/12",
+                "<%= spec.ip.split(".")[0...-1].append(0).join(".") %>/24"
+              ]
+            }
+          },
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "ROUTE",
+              "DestinationPrefix": "10.100.200.0/24",
+              "NeedEncap": true
+            }
+          },
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "ROUTE",
+              "DestinationPrefix": "<%= spec.ip %>/32",
+              "NeedEncap": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+'
+  Set-Content -Path /etc/cni/net.d/50-flannel.conflist -Value $confFile
+
+
+  /var/vcap/packages/flanneld-windows/flanneld.exe `
+    --etcd-endpoints=<%= etcd_endpoints %> `
+    --ip-masq `
+    --etcd-certfile=/var/vcap/jobs/flanneld-windows/config/etcd-client.crt `
+    --etcd-keyfile=/var/vcap/jobs/flanneld-windows/config/etcd-client.key `
+    --etcd-cafile=/var/vcap/jobs/flanneld-windows/config/etcd-ca.crt
+}
+
+start_flanneld

--- a/jobs/flanneld-windows/templates/config/etcd-ca.crt.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-ca.crt.erb
@@ -1,0 +1,2 @@
+<%= p('tls.etcdctl.ca') %>
+

--- a/jobs/flanneld-windows/templates/config/etcd-client.crt.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-client.crt.erb
@@ -1,0 +1,2 @@
+<%= p('tls.etcdctl.certificate') %>
+

--- a/jobs/flanneld-windows/templates/config/etcd-client.key.erb
+++ b/jobs/flanneld-windows/templates/config/etcd-client.key.erb
@@ -1,0 +1,2 @@
+<%= p('tls.etcdctl.private_key') %>
+

--- a/jobs/kube-proxy-windows/monit
+++ b/jobs/kube-proxy-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "kube-proxy",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\kube-proxy-windows\\bin\\kube_proxy_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/kube-proxy-windows/spec
+++ b/jobs/kube-proxy-windows/spec
@@ -1,0 +1,38 @@
+---
+name: kube-proxy-windows
+
+templates:
+  bin/kube_proxy_ctl.ps1.erb: bin/kube_proxy_ctl.ps1
+  config/kubeconfig.erb: config/kubeconfig
+  config/config.yml.erb: config/config.yml
+  config/ca.pem.erb: config/ca.pem
+
+packages:
+- kubernetes-windows
+
+properties:
+  api-token:
+    description: The password for the kube-proxy user
+  cloud-provider:
+    description: The type of cloud-provider that is being deployed
+  tls.kubernetes:
+    description: Certificate and private key for the Kubernetes master
+  kube-proxy-configuration:
+    description: The Kube-proxy will load its initial configuration from this.
+      Omit this to use the built-in default configuration values.
+      Command-line flags override configuration.
+      This is the recommended way to configure kube-proxy as the command line flags for kube-proxy are being deprecated.
+    example: |
+      kube-proxy-configuration:
+        feature-gates:
+          CPUManager: true
+          DryRun: false
+        cleanup: false
+  k8s-args:
+    description: Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ for reference.
+    example: |
+      k8s-args:
+        feature-gates:
+          CPUManager: true
+          DryRun: false
+        cleanup: false

--- a/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
+++ b/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
@@ -1,0 +1,51 @@
+trap { $host.SetShouldExit(1) }
+
+function ensure_kubelet_is_running {
+  curl.exe --fail http://localhost:10248/healthz
+  if (-not $?) {
+    throw "kubelet is not available"
+  }
+}
+
+function start_kube_proxy {
+  $network = Get-HnsNetwork | ? Type -Eq L2Bridge
+  $env:KUBE_NETWORK = $network.Name
+
+  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
+}
+
+function check_for_networking {
+  $subnetConfig="/run/flannel/subnet.env"
+
+  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  {
+    throw "$subnetConfig does not exist, waiting for flannel initialization"
+  }
+}
+
+function misc_setup {
+  # Prestart doesn't get run again on recreate, so need to do this in ctl
+  Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
+
+  <% if_p('cloud-provider') do |cloud_provider| %>
+    <% if cloud_provider == "vsphere" %>
+  # Override the hostname to work around
+  # vSphere cloud provider ignoring hostname override
+  # and kubernetes requiring all-lowercase node names
+  $ComputerName = (cat C:\var\vcap\bosh\settings.json | ConvertFrom-Json).agent_id
+  Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname" -value $ComputerName
+    <% end %>
+  <% end %>
+
+  # Needed until https://github.com/kubernetes/kubernetes/pull/71147 is merged
+  mkdir -force /sys/class/dmi/id
+  (wmic csproduct get IdentifyingNumber).Split([Environment]::Newline)[2] | Out-File -Encoding ASCII /sys/class/dmi/id/product_serial
+}
+
+function main() {
+  misc_setup
+  check_for_networking
+  start_kube_proxy
+}
+
+main

--- a/jobs/kube-proxy-windows/templates/config/ca.pem.erb
+++ b/jobs/kube-proxy-windows/templates/config/ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubernetes.ca') %>

--- a/jobs/kube-proxy-windows/templates/config/config.yml.erb
+++ b/jobs/kube-proxy-windows/templates/config/config.yml.erb
@@ -1,0 +1,13 @@
+<%
+  hostname = ""
+  if_p('cloud-provider') do |cloud_provider|
+    if cloud_provider == "gce" || cloud_provider == "azure" || cloud_provider == "vsphere"
+    else
+      hostname = spec.ip
+    end
+  end.else do
+    hostname = spec.ip
+  end
+%>
+<% require 'yaml' %><%= p('kube-proxy-configuration').to_yaml %>
+hostnameOverride: <%= hostname %>

--- a/jobs/kube-proxy-windows/templates/config/kubeconfig.erb
+++ b/jobs/kube-proxy-windows/templates/config/kubeconfig.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: "C:\\var\\vcap\\jobs\\kube-proxy-windows\\config\\ca.pem"
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kube-proxy
+  name: kube-proxy
+current-context: kube-proxy
+users:
+- name: kube-proxy
+  user:
+    token: "<%= p("api-token") %>"

--- a/jobs/kubelet-windows/monit
+++ b/jobs/kubelet-windows/monit
@@ -1,0 +1,11 @@
+{
+  "processes": [
+    {
+      "name": "kubelet",
+      "executable": "powershell",
+      "args": ["C:\\var\\vcap\\jobs\\kubelet-windows\\bin\\kubelet_ctl.ps1"],
+      "env": {}
+    }
+  ]
+}
+

--- a/jobs/kubelet-windows/spec
+++ b/jobs/kubelet-windows/spec
@@ -1,0 +1,61 @@
+name: kubelet-windows
+templates:
+  bin/drain.ps1.erb: bin/drain.ps1
+  bin/kubelet_ctl.ps1.erb: bin/kubelet_ctl.ps1
+  config/apiserver-ca.pem.erb: config/apiserver-ca.pem
+  config/cloud-provider.ini.erb: config/cloud-provider.ini
+  config/Dockerfile: config/Dockerfile
+  config/kubeconfig-drain.erb: config/kubeconfig-drain
+  config/kubeconfig.erb: config/kubeconfig
+  config/kubelet-client-ca.pem.erb: config/kubelet-client-ca.pem
+  config/kubelet-key.pem.erb: config/kubelet-key.pem
+  config/kubelet.pem.erb: config/kubelet.pem
+  config/kubeletconfig.yml.erb: config/kubeletconfig.yml
+  config/openstack-ca.crt.erb: config/openstack-ca.crt
+  config/service_key.json.erb: config/service_key.json
+packages:
+- kubernetes-windows
+- cni-windows
+properties:
+  api-token:
+    description: The token to access Kubernetes API
+  cloud-provider:
+    description: "The type of cloud-provider that is being deployed"
+  drain-api-token:
+    description: The token to access Kubernetes API used to drain the kubelet.
+  http_proxy:
+    description: http_proxy env var for cloud provider interactions, i.e. for the
+      kubelet
+  https_proxy:
+    description: https_proxy env var for cloud provider interactions, i.e. for the
+      kubelet
+  kubelet-configuration:
+    description: The Kubelet will load its initial configuration from this.
+      Omit this to use the built-in default configuration values.
+      Command-line flags override configuration.
+  k8s-args:
+    description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
+    example: |
+      k8s-args:
+        address: 10.0.0.1
+        docker-only: null
+  no_proxy:
+    description: no_proxy env var for cloud provider interactions, i.e. for the kubelet
+  tls.kubelet:
+    description: Certificate and private key for the Kubernetes worker
+    parameters:
+      duration: {}
+      key_length: {}
+    type: {}
+  tls.kubelet-client-ca.certificate:
+    description: CA certificate of the authority granting access to kubelet server
+  tls.kubernetes:
+    description: Certificate and private key for the Kubernetes master
+consumes:
+- name: cloud-provider
+  optional: true
+  type: cloud-provider
+provides:
+- name: kubernetes-workers
+  type: kubernetes-workers
+

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -1,0 +1,69 @@
+trap { $host.SetShouldExit(1) }
+
+$OutLog = "C:\var\vcap\sys\log\kubelet-windows\drain.stdout.log"
+$ErrLog = "C:\var\vcap\sys\log\kubelet-windows\drain.stderr.log"
+
+
+function main {
+  if (kubelet_is_running) {
+    retry "drain_kubelet" $function:drain_kubelet
+    # watch_disks TODO(BM/LH): implement this?
+    retry "delete_drained_node" $function:delete_drained_node
+  }
+  echo "0"
+}
+
+function drain_kubelet() {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain `
+    get nodes -o json | ConvertFrom-Json).Items
+  $node_name=($nodes | ? { $_.metadata.labels."bosh.id" -eq "<%= spec.id %>" }).metadata.name
+
+  if (!$node_name) {
+    return $true
+  }
+  /var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain drain "${node_name}" `
+    --grace-period 10 --force --delete-local-data --ignore-daemonsets
+  return $?
+}
+
+function delete_drained_node() {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain `
+    get nodes -o json | ConvertFrom-Json).Items
+  $node_name=($nodes | ? { $_.metadata.labels."bosh.id" -eq "<%= spec.id %>" }).metadata.name
+
+  if (!$node_name) {
+    return $true
+  }
+  /var/vcap/packages/kubernetes-windows/bin/kubectl `
+    --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain delete node "${node_name}" `
+    --ignore-not-found | Out-Null
+  return $?
+}
+
+function retry($name, $func) {
+  $attempt_number=1
+  $max_attempts=10
+
+  do {
+    $result=$func.Invoke()
+    if ($result) {
+      echo "Successfully $name" | Out-File -FilePath $OutLog -encoding ascii
+      return
+    }
+    echo ("[{0}] Unsuccessful {1}, retrying attempt {2} out of {3}" -f (Get-Date -UFormat %s), $name, $attempt_number, $max_attempts) | Out-File -FilePath $OutLog -encoding ascii
+    $attempt_number=$attempt_number + 1
+    sleep 1
+  } while ($attempt_number -le $max_attempts)
+
+  throw "Failed all retry attempts for $name"
+}
+
+function kubelet_is_running() {
+  curl.exe --silent --fail http://localhost:10248/healthz
+  return $?
+}
+
+main

--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -1,0 +1,148 @@
+trap { $host.SetShouldExit(1) }
+
+$env:PATH+=";C:\var\vcap\packages\docker\docker\;"
+
+<% iaas = nil %>
+<% if_p('cloud-provider') do |cloud_provider| %>
+  <% iaas = cloud_provider %>
+  $cloud_provider="<%= cloud_provider %>"
+<% end %>
+
+<% if_link('cloud-provider') do |cloud_provider| %>
+    $cloud_config="/var/vcap/jobs/kubelet-windows/config/cloud-provider.ini"
+    <% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| %>
+      $env:GOOGLE_APPLICATION_CREDENTIALS="/var/vcap/jobs/kubelet-windows/config/service_key.json"
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.aws.access_key_id') do |access_key_id| %>
+      $env:AWS_ACCESS_KEY_ID="<%= access_key_id %>"
+    <% end %>
+    <% cloud_provider.if_p('cloud-provider.aws.secret_access_key') do |secret_access_key| %>
+      $env:AWS_SECRET_ACCESS_KEY="<%= secret_access_key %>"
+    <% end %>
+<% end %>
+
+<%
+  labels = ["spec.ip=#{spec.ip}","bosh.id=#{spec.id}","bosh.zone=#{spec.az}"]
+  if iaas=="vsphere"
+    labels << "failure-domain.beta.kubernetes.io/zone=#{spec.az}"
+  end
+
+  if_p('k8s-args') do |args|
+    custom_labels = args.fetch('node-labels', "").split(",")
+    labels = custom_labels + labels
+    args.delete('node-labels')
+  end
+
+  labels = labels.join(',')
+%>
+
+<% if_p('http_proxy') do |http_proxy| %>
+$env:HTTP_PROXY=<%= http_proxy %>
+<% end %>
+<% if_p('https_proxy') do |https_proxy| %>
+$env:HTTPS_PROXY=<%= https_proxy %>
+<% end %>
+<% if_p('no_proxy') do |no_proxy| %>
+$env:NO_PROXY=<%= no_proxy %>
+<% end %>
+
+function delete_stale_drained_node {
+  $nodes=(/var/vcap/packages/kubernetes-windows/bin/kubectl --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain get nodes -o json | ConvertFrom-Json).Items
+  $nodes | ForEach-Object {
+    if ($_.metadata.labels."bosh.id" -eq "<= spec.id %>") {
+      if (($_.status.conditions | ? type -eq "Ready").status -ne "True") {
+        /var/vcap/packages/kubernetes-windows/bin/kubectl --kubeconfig /var/vcap/jobs/kubelet-windows/config/kubeconfig-drain delete node "${node_name}" --ignore-not-found
+      }
+    }
+  }
+}
+
+function get_hostname_override {
+  if ($cloud_provider -in "gce", "azure") {
+    return ""
+  } else {
+    return "<%= spec.ip %>"
+  }
+}
+
+function start_kubelet {
+  <%-
+    include_config = false
+    if !iaas.nil? and iaas != "vsphere"
+      if_link('cloud-provider') do
+        include_config = true
+      end
+    end
+  -%>
+  mkdir -force C:\tmp # workaround for conformance tests
+
+  /var/vcap/packages/kubernetes-windows/bin/kubelet `
+  <%-
+    if_p('k8s-args') do |args|
+      args.each do |flag, value|
+        valueString = ""
+
+        if value.nil?
+          # Do nothing to supports args-less flags (--example)
+        elsif value.is_a? Array
+          valueString = "=#{value.join(",")}"
+        elsif value.is_a? Hash
+          valueString = "=#{value.map { |k,v| "#{k}=#{v}" }.join(",")}"
+        else
+          valueString = "=#{value}"
+        end
+  -%>
+    <%= "--#{flag}#{valueString}" %> `
+  <%-
+      end
+    end
+  -%>
+    <% if include_config -%>--cloud-config=${cloud_config}<% end %> `
+    <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> `
+    --hostname-override=$(get_hostname_override) `
+    --node-labels=<%= labels %> `
+    --config="/var/vcap/jobs/kubelet-windows/config/kubeletconfig.yml"
+}
+
+function check_for_networking {
+  $subnetConfig="/run/flannel/subnet.env"
+
+  if (-not ([System.IO.File]::Exists($subnetConfig)))
+  {
+    throw "$subnetConfig does not exist, waiting for flannel initialization"
+  }
+}
+
+function load_base_images {
+  # Temporary workaround until we bring our own images
+  docker version
+  if (-not $?) {
+    throw "docker is not available"
+  }
+
+  docker pull mcr.microsoft.com/windows/nanoserver:1809
+  docker tag (docker images mcr.microsoft.com/windows/nanoserver:1809 -q) mcr.microsoft.com/windows/nanoserver
+  docker build -t kubeletwin/pause /var/vcap/jobs/kubelet-windows/config
+
+  Start-Job -ScriptBlock {
+    docker pull mcr.microsoft.com/windows/servercore:ltsc2019
+    docker tag (docker images mcr.microsoft.com/windows/servercore:ltsc2019 -q) mcr.microsoft.com/windows/servercore
+  }
+}
+
+function set_acls {
+  $ar = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Users", "ReadAndExecute,CreateFiles,AppendData", "ContainerInherit, ObjectInherit", "None", "Allow")
+  $acl = Get-Acl C:\var
+  $acl.SetAccessRule($ar)
+  Set-Acl C:\var $acl
+}
+
+function main {
+  delete_stale_drained_node
+  check_for_networking
+  load_base_images
+  set_acls
+  start_kubelet
+}
+
+main

--- a/jobs/kubelet-windows/templates/bin/post-start.ps1
+++ b/jobs/kubelet-windows/templates/bin/post-start.ps1
@@ -1,0 +1,29 @@
+trap { $host.SetShouldExit(1) }
+
+function kubelet_is_running() {
+  curl.exe --fail http://localhost:10248/healthz
+  return $?
+}
+
+function main() {
+    retry "passed kubelet healthcheck" $function:kubelet_is_running
+}
+
+function retry($name, $func) {
+  $attempt_number=1
+  $max_attempts=10
+
+  do {
+    $result=$func.Invoke()
+    if ($result) {
+      echo "Successfully $name"
+      return $true
+    }
+    echo ("[{0}] Unsuccessful {1}, retrying attempt {2} out of {3}" -f (Get-Date -UFormat %s), $name, $attempt_number, $max_attempts)
+    $attempt_number=$attempt_number + 1
+    sleep 1
+  } while ($attempt_number -le $max_attempts)
+
+  echo "Failed all retry attempts for $name"
+  return $false
+}

--- a/jobs/kubelet-windows/templates/config/Dockerfile
+++ b/jobs/kubelet-windows/templates/config/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/nanoserver
+
+CMD cmd /c ping -t localhost

--- a/jobs/kubelet-windows/templates/config/apiserver-ca.pem.erb
+++ b/jobs/kubelet-windows/templates/config/apiserver-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubernetes.ca') %>

--- a/jobs/kubelet-windows/templates/config/cloud-provider.ini.erb
+++ b/jobs/kubelet-windows/templates/config/cloud-provider.ini.erb
@@ -1,0 +1,26 @@
+<%
+  def escape(value)
+    if value.kind_of? String
+      return value.gsub("\\", "\\\\\\").gsub("\"", "\\\"")
+    else
+      value
+    end
+  end
+
+  cloud_config=""
+
+  if_link('cloud-provider') do |cloud_provider|
+    if cloud_provider.p('cloud-provider.type').downcase == "azure"
+      cloud_config += cloud_provider.p('cloud-config', {}).to_yaml
+    else
+      cloud_provider.p('cloud-config', {}).each do |header, properties|
+        cloud_config += "[#{header}]\n"
+        properties.each do |property, value|
+          raise TypeError, "Invalid value of type #{value.class} for property \"#{property}\"" if value.is_a? Enumerable
+          cloud_config += "#{property}=\"#{escape(value)}\"\n"
+        end
+      end
+    end
+  end
+%>
+<%= cloud_config %>

--- a/jobs/kubelet-windows/templates/config/kubeconfig-drain.erb
+++ b/jobs/kubelet-windows/templates/config/kubeconfig-drain.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: C:\var\vcap\jobs\kubelet-windows\config\apiserver-ca.pem
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet-drain
+  name: kubelet-drain
+current-context: kubelet-drain
+users:
+- name: kubelet-drain
+  user:
+    token: "<%= p("drain-api-token") %>"

--- a/jobs/kubelet-windows/templates/config/kubeconfig.erb
+++ b/jobs/kubelet-windows/templates/config/kubeconfig.erb
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: C:\var\vcap\jobs\kubelet-windows\config\apiserver-ca.pem
+    server: https://master.cfcr.internal:8443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+  user:
+    token: "<%= p("api-token") %>"

--- a/jobs/kubelet-windows/templates/config/kubelet-client-ca.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet-client-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.kubelet-client-ca.certificate') %>

--- a/jobs/kubelet-windows/templates/config/kubelet-key.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet-key.pem.erb
@@ -1,0 +1,1 @@
+<%= p("tls.kubelet.private_key") %>

--- a/jobs/kubelet-windows/templates/config/kubelet.pem.erb
+++ b/jobs/kubelet-windows/templates/config/kubelet.pem.erb
@@ -1,0 +1,2 @@
+<%= p("tls.kubelet.certificate") %>
+<%= p("tls.kubelet.ca") %>

--- a/jobs/kubelet-windows/templates/config/kubeletconfig.yml.erb
+++ b/jobs/kubelet-windows/templates/config/kubeletconfig.yml.erb
@@ -1,0 +1,1 @@
+<% require 'yaml' %><%= p('kubelet-configuration').to_yaml %>

--- a/jobs/kubelet-windows/templates/config/openstack-ca.crt.erb
+++ b/jobs/kubelet-windows/templates/config/openstack-ca.crt.erb
@@ -1,0 +1,5 @@
+<% if_link('cloud-provider') do |cloud_provider| -%>
+<% cloud_provider.if_p('cloud-provider.openstack.ca-file') do |ca_file| -%>
+<%= ca_file %>
+<% end -%>
+<% end -%>

--- a/jobs/kubelet-windows/templates/config/service_key.json.erb
+++ b/jobs/kubelet-windows/templates/config/service_key.json.erb
@@ -1,0 +1,5 @@
+<% if_link('cloud-provider') do |cloud_provider| -%>
+<% cloud_provider.if_p('cloud-provider.gce.service_key') do |service_key| -%>
+<%= service_key %>
+<% end -%>
+<% end -%>

--- a/jobs/kubo-dns-aliases-windows/spec
+++ b/jobs/kubo-dns-aliases-windows/spec
@@ -1,0 +1,13 @@
+---
+name: kubo-dns-aliases
+
+templates:
+  dns/aliases.json.erb: dns/aliases.json
+
+consumes:
+- name: etcd
+  type: etcd
+- name: kube-apiserver
+  type: kube-apiserver
+
+properties: {}

--- a/jobs/kubo-dns-aliases-windows/spec
+++ b/jobs/kubo-dns-aliases-windows/spec
@@ -1,5 +1,5 @@
 ---
-name: kubo-dns-aliases
+name: kubo-dns-aliases-windows
 
 templates:
   dns/aliases.json.erb: dns/aliases.json

--- a/jobs/kubo-dns-aliases-windows/templates/dns/aliases.json.erb
+++ b/jobs/kubo-dns-aliases-windows/templates/dns/aliases.json.erb
@@ -1,0 +1,24 @@
+<%=
+# This file is required by the bosh-dns job which is applied through the runtime config
+
+def wildcard_name(name)
+  name.split('.').collect!.with_index {|s, i| (i == 0) ? '*' : s}.join('.')
+end
+
+# As defined by cfcr-etcd-release
+def get_etcd_alias(server)
+  node_name = "#{server.name.gsub('_','-')}-#{server.index}"
+  "#{node_name}.#{link('etcd').p('etcd.dns_suffix')}"
+end
+
+master_node_dns = link('kube-apiserver').address
+aliases = { 'master.cfcr.internal' => [ wildcard_name(master_node_dns) ] }
+
+if link('etcd').p('etcd.dns_suffix', false) != false
+  link('etcd').instances.each do |instance|
+    aliases.merge!({ get_etcd_alias(instance) => [instance.address] })
+  end
+end
+
+JSON.dump(aliases)
+%>

--- a/packages/cni-windows/packaging
+++ b/packages/cni-windows/packaging
@@ -1,0 +1,8 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+mkdir ${env:BOSH_INSTALL_TARGET}/bin
+$tgz=(get-childitem cni/cni-plugins-windows-amd64*.tgz).Name
+tar -xzf cni/$tgz -C ${env:BOSH_INSTALL_TARGET}/bin/

--- a/packages/cni-windows/packaging
+++ b/packages/cni-windows/packaging
@@ -1,5 +1,3 @@
-. ./exiter.ps1
-
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 

--- a/packages/cni-windows/spec
+++ b/packages/cni-windows/spec
@@ -1,0 +1,6 @@
+---
+name: cni-windows
+
+files:
+- cni/cni-plugins-windows-amd64-c74e0e996.tgz
+- exiter.ps1

--- a/packages/cni-windows/spec
+++ b/packages/cni-windows/spec
@@ -3,4 +3,3 @@ name: cni-windows
 
 files:
 - cni/cni-plugins-windows-amd64-c74e0e996.tgz
-- exiter.ps1

--- a/packages/flanneld-windows/packaging
+++ b/packages/flanneld-windows/packaging
@@ -1,0 +1,9 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+
+$FLANNELD_VERSION="0.11.0"
+tar xvf flannel-v${FLANNELD_VERSION}-windows-amd64.tar.gz
+Copy-Item flanneld.exe "${env:BOSH_INSTALL_TARGET}/flanneld.exe"

--- a/packages/flanneld-windows/packaging
+++ b/packages/flanneld-windows/packaging
@@ -1,5 +1,3 @@
-. ./exiter.ps1
-
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 

--- a/packages/flanneld-windows/spec
+++ b/packages/flanneld-windows/spec
@@ -1,0 +1,8 @@
+---
+name: flanneld-windows
+
+dependencies:
+
+files:
+- flannel-v0.11.0-windows-amd64.tar.gz
+- exiter.ps1

--- a/packages/flanneld-windows/spec
+++ b/packages/flanneld-windows/spec
@@ -5,4 +5,3 @@ dependencies:
 
 files:
 - flannel-v0.11.0-windows-amd64.tar.gz
-- exiter.ps1

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -1,5 +1,3 @@
-. ./exiter.ps1
-
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -1,0 +1,10 @@
+. ./exiter.ps1
+
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$KUBERNETES_VERSION="1.14.4"
+
+New-Item -Path "${env:BOSH_INSTALL_TARGET}" -Name "bin" -ItemType "directory"
+
+Copy-Item "kubernetes-windows-${KUBERNETES_VERSION}/*" "${env:BOSH_INSTALL_TARGET}/bin"

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -1,0 +1,6 @@
+---
+name: kubernetes-windows
+
+files:
+- kubernetes-windows-1.14.4/*
+- exiter.ps1

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -3,4 +3,3 @@ name: kubernetes-windows
 
 files:
 - kubernetes-windows-1.14.4/*
-- exiter.ps1

--- a/src/exiter.ps1
+++ b/src/exiter.ps1
@@ -1,0 +1,6 @@
+exit 0
+# The reason for needing this file is to make `bosh export-release` happy.
+# BOSH doesn't know what job to export, so it tries to export a windows job
+# against a linux stemcell. This is a file that will cause a bash script to
+# immediately exit (such as when exporting a release) but be ignored when run
+# in powershell.

--- a/src/exiter.ps1
+++ b/src/exiter.ps1
@@ -1,6 +1,0 @@
-exit 0
-# The reason for needing this file is to make `bosh export-release` happy.
-# BOSH doesn't know what job to export, so it tries to export a windows job
-# against a linux stemcell. This is a file that will cause a bash script to
-# immediately exit (such as when exporting a release) but be ignored when run
-# in powershell.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR recombines the kubo for Windows jobs back into this release. We can now compile these jobs specifically against a Windows stemcell and release separate precompiled releases for Windows and Linux

**How can this PR be verified?**
Run the pipelines
**Is there any change in kubo-deployment?**
Yes, this change https://github.com/cloudfoundry-incubator/kubo-deployment/pull/410
**Is there any change in kubo-ci?**
Yes, those are being applied as well.
**Does this affect upgrade, or is there any migration required?**
No
**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
This release recombines the kubo-release and kubo-release-windows. It no longer depends on kubo-release-windows. When using Windows workers the precompiled releases for docker-boshrelease and kubo-release will be replaced with the uncompiled releases.
```
