### PR TITLE
Update ubuntu dependencies to fix CVEs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -22,14 +22,14 @@ cni/util-linux_2.27.1-6ubuntu3_amd64.deb:
   size: 847730
   object_id: 27eb3ec3-220f-4a25-6c4f-ec219c37ac8d
   sha: 568f62cb031608ab09ba1e3c2121e9e8b92dcae4
-conntrack/conntrack_1.4.1-1.deb:
-  size: 25112
-  object_id: 9bf859c2-93aa-48b0-69f9-5903f0b4acbe
-  sha: 494df11d77a1dd31fbc1e0e8c7946957ef5a74af
-conntrack/libnetfilter-conntrack3_1.0.4-1.deb:
-  size: 45872
-  object_id: 42a59368-8ae3-4502-480b-56ecd3f40f7a
-  sha: 743b497bd6a6491a8cad11c04103e55c7a9cc93c
+conntrack/conntrack_1.4.3-3_amd64.deb:
+  size: 27346
+  object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c
+  sha: sha256:ad9eae1cf2191981dd687b681ee701a2f3adfca5b89b45c2ff74c0f8d32113ff
+conntrack/libnetfilter-conntrack3_1.0.5-1_amd64.deb:
+  size: 36634
+  object_id: 1d6d9546-e933-46bd-60f9-00bd8eb91c59
+  sha: sha256:18609b2b131bc0dedf4a2c3fbf61b30d16c3d3a96cd43d604e8fc53ebc1e30eb
 container-images/coredns_coredns:1.4.0.tgz:
   size: 12997721
   object_id: 14779ec2-2266-48eb-77d6-a732d3721d1f
@@ -110,10 +110,10 @@ kubernetes-windows-1.14.5/kubelet.exe:
   size: 116709376
   object_id: 9bf4d99a-d1af-4681-58d5-0bc30b6d1ebc
   sha: 788cdd100e7eb98194c4d2ae83427b726daa7e3c
-libmnl0_1.0.3-3.deb:
-  size: 11416
-  object_id: 245e085f-1ad2-447d-67bb-1894b960c571
-  sha: dcb0b572f1207ad192d8cb1a9010fc6dd22d0000
+libmnl0_1.0.3-5_amd64.deb:
+  size: 11970
+  object_id: 30b1e2c0-4194-47f2-544f-f55eb76b9101
+  sha: sha256:abd749bdd206e51fc9ac19ef27d4452a2d9df46b5b1a276d50a065af901ab1c4
 libtool-2.4.6.tar.gz:
   size: 1806697
   object_id: 670cc8a2-75d8-4fb5-465f-270395cb9373
@@ -124,8 +124,8 @@ nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   sha: ec2e96e73feb5215605c9f0254cad05d9cc5688a
 nfs-debs/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb:
   size: 114014
-  object_id: cbdc50ad-e7f5-4a3b-6115-77392061bd76
-  sha: 57d69f44f3e058e48a7b79595d36076eb21f5942
+  object_id: 0fa38188-cd2c-417f-7407-02367bc99c7d
+  sha: sha256:e1acdffde386a4da7de46166ffd199771a13498f5d4fc38d61b3fa0eba305572
 nfs-debs/libnfsidmap2_0.25-5_amd64.deb:
   size: 32182
   object_id: 59ba4d66-fb63-4a62-75da-8502169d85cd

--- a/jobs/kubernetes-dependencies/templates/bin/pre-start.erb
+++ b/jobs/kubernetes-dependencies/templates/bin/pre-start.erb
@@ -9,24 +9,32 @@ NFS_PACKAGES=/var/vcap/packages/nfs
 install_package() {
   local package=$1
 
+  count_failure=0
   until dpkg -i "$package"; do
+    if [[ $count_failure -ge 100 ]]; then
+      echo "Failed installing package $package after 100 attempts."
+      exit 1
+    fi
     echo "Retrying '$package'"
+    count_failure=$(($count_failure+1))
     sleep 2
   done
 }
 
-install_package "${CONNTRACK_PACKAGES:?}/libmnl0_1.0.3-3.deb"
+install_package "${CONNTRACK_PACKAGES:?}/libmnl0_1.0.3-5_amd64.deb"
 
-install_package "${CONNTRACK_PACKAGES:?}/libnetfilter-conntrack3_1.0.4-1.deb"
-install_package "${CONNTRACK_PACKAGES:?}/conntrack_1.4.1-1.deb"
+install_package "${CONNTRACK_PACKAGES:?}/libnetfilter-conntrack3_1.0.5-1_amd64.deb"
+install_package "${CONNTRACK_PACKAGES:?}/conntrack_1.4.3-3_amd64.deb"
 
 install_package "${IPSET_PACKAGES:?}/libipset3_6.20.1-1_amd64.deb"
 install_package "${IPSET_PACKAGES:?}/ipset_6.20.1-1_amd64.deb"
 
 <% if_p("nfs") do |nfs|
   if nfs %>
+  ## libevent has a known CVE. We need ubuntu disco to get a fixed version
   install_package "${NFS_PACKAGES:?}/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb"
   install_package "${NFS_PACKAGES:?}/keyutils_1.5.9-8ubuntu1_amd64.deb"
+  ## rpcbind has a known CVE. We need ubuntu disco to get a fixed version
   install_package "${NFS_PACKAGES:?}/rpcbind_0.2.3-0.2_amd64.deb"
   install_package "${NFS_PACKAGES:?}/libnfsidmap2_0.25-5_amd64.deb"
   install_package "${NFS_PACKAGES:?}/nfs-common_1:1.2.8-9ubuntu12.1_amd64.deb"


### PR DESCRIPTION
Two deps, libevent and rpcbind, cannot be updated without pulling in changes from ubuntu
"disco" distro, which is too far forward (not tested against K8s upstream)

**What this PR does / why we need it**:

Fix CVEs against dependencies

**How can this PR be verified?**

Runs correctly and the dependencies are not on the list of CVEs

**Is there any change in kubo-deployment?**

No

**Is there any change in kubo-ci?**

No

**Does this affect upgrade, or is there any migration required?**

No

**Which issue(s) this PR fixes:**

https://www.pivotaltracker.com/story/show/167631002

**Release note**:

PLEASE ASK PMs IF THEY WANT THE FOLLOWING IN THE RELEASE NOTES:

The following CVEs are NOT fixed in this version because patches have not been backported to Ubuntu Xenial:

libevent-2.0.21
1.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10195
2.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6272
3.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10196
4.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10197

rpcbind
1.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8779
2.) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7236

