### PR TITLE
Expose flannel and apiserver CIDR customizations

### DIFF
--- a/jobs/flanneld/spec
+++ b/jobs/flanneld/spec
@@ -34,3 +34,9 @@ properties:
 consumes:
 - name: etcd
   type: etcd
+
+provides:
+- name: flanneld
+  type: flanneld
+  properties:
+  - pod-network-cidr

--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -81,4 +81,5 @@ provides:
   - admin-username
   - admin-password
   - tls.kubernetes.ca
+  - k8s-args
   type: kube-apiserver


### PR DESCRIPTION
We need to expose these so that Windows jobs can consume them as links