### PR TITLE
Add special case for Azure Availability Sets

### DIFF
--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -29,7 +29,12 @@ DATA_DIR=/var/vcap/store/kubernetes
 <% end %>
 
 <%
-  labels = ["spec.ip=#{spec.ip}","bosh.id=#{spec.id}","bosh.zone=#{spec.az}"]
+  labels = ["spec.ip=#{spec.ip}","bosh.id=#{spec.id}"]
+  # special case for Azure, when Availability Sets are configured, OpsMan indicates their usage by setting zone="Availability Sets"
+  unless iaas == "azure" && "#{spec.az}" == "Availability Sets"
+    labels << "bosh.zone=#{spec.az}"
+  end
+
   if iaas=="vsphere"
     labels << "failure-domain.beta.kubernetes.io/zone=#{spec.az}"
   end

--- a/spec/kubelet_ctl_spec.rb
+++ b/spec/kubelet_ctl_spec.rb
@@ -100,6 +100,18 @@ describe 'kubelet_ctl' do
     expect(rendered_kubelet_ctl).to include('export no_proxy=noproxy.example.com,noproxy.example.net')
     expect(rendered_kubelet_ctl).to include('export NO_PROXY=noproxy.example.com,noproxy.example.net')
   end
+
+  context 'when cloud provider is azure' do
+    it 'avoids setting bosh.zone to an (illegal) value "Availability Sets" that is set by OpsMan 2.5+' do
+      manifest_properties = {
+          'cloud-provider' => 'azure'
+      }
+
+      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, az="Availability Sets")
+      expect(rendered_kubelet_ctl).to include('cloud_provider="azure"')
+      expect(rendered_kubelet_ctl).not_to include('bosh.zone=Availability Sets')
+    end
+  end
 end
 
 def call_get_hostname_override(rendered_kubelet_ctl, executable_path)


### PR DESCRIPTION
Add special case for Azure Availability Sets

As a workaround, we add a conditional to sense the Azure-only,
artificial zone value (the string "Availability Sets"),
and omit its usage as a value for the output of
environmental variable 'bosh.zone'.

**What this PR does / why we need it**:
Adapt to OpsMan 2.5+; fix breakage on Azure

**How can this PR be verified?**
Local test; integration pipeline under way

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**
https://pivotal-spike.atlassian.net/browse/PKS-349

**Release note**:

```release-note
Fixes issue that prevented deployment with Azure Availability Sets
```
