### PR TITLE
Add docker-windows

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -50,6 +50,10 @@ container-images/pcfkubo_nginx-bionic:1.0.0.tgz:
   size: 77661967
   object_id: f2575255-59f6-442e-5f69-d10e5a24e178
   sha: c677df2c93e1a15604285ea0f32b121011dcacdd
+docker-windows/docker-18-09-9.zip:
+  size: 49417290
+  object_id: a4d105e0-c646-4d1b-5aaa-c8d6467e1b5a
+  sha: 269a6baacd95e7b59f2e4695cca0b662359e497e
 etcdctl-3.0.7:
   size: 18427584
   object_id: 32221476-5c3d-4ec7-5869-44c989cc3077

--- a/jobs/docker-windows/spec
+++ b/jobs/docker-windows/spec
@@ -1,0 +1,8 @@
+---
+name: docker-windows
+
+templates:
+  pre-start.ps1: bin/pre-start.ps1
+
+packages:
+- docker-windows

--- a/jobs/docker-windows/templates/pre-start.ps1
+++ b/jobs/docker-windows/templates/pre-start.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$AddedFolder= "C:\var\vcap\packages\docker-windows\docker\"
+
+$OldPath=(Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
+
+if (-not $OldPath.Contains($AddedFolder)) {
+  $NewPath=$OldPath+';'+$AddedFolder
+  Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+}
+
+C:\var\vcap\packages\docker-windows\docker\dockerd --register-service
+
+Start-Service Docker

--- a/packages/docker-windows/packaging
+++ b/packages/docker-windows/packaging
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
+$path=(Get-ChildItem "docker-windows/docker*.zip").FullName
+
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive -Path $path -DestinationPath ${BOSH_INSTALL_TARGET}
+} else {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($path, ${BOSH_INSTALL_TARGET})
+}
+

--- a/packages/docker-windows/spec
+++ b/packages/docker-windows/spec
@@ -1,0 +1,7 @@
+---
+name: docker-windows
+
+dependencies: []
+
+files:
+- docker-windows/docker-*.zip


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds docker-windows job. Needed to avoid depending on https://github.com/cloudfoundry/windows-tools-release/ and since @srm09 said it was causing problems to have it in https://github.com/cloudfoundry-incubator/docker-boshrelease 

**Is there any change in kubo-deployment?**
Yes, will link once I create that PR

**Is there any change in kubo-ci?**
Yes, will link once I create that PR

**Does this affect upgrade, or is there any migration required?**
No
