### PR TITLE
bump coredns from 1.4 to 1.6.6

### DIFF
--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -55,16 +55,15 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf {
-          policy sequential # needed for workloads to be able to use BOSH-DNS
-        }
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload
@@ -102,7 +101,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.4.0
+        image: coredns/coredns:1.6.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
bump to the last coredns version 1.6.6. 
It solves some CVE such as https://github.com/miekg/dns/issues/1043
https://github.com/coredns/coredns/blob/master/notes/coredns-1.6.6.md

**Is there any change in kubo-deployment?**
no
**Is there any change in kubo-ci?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**

**Release note**:
```release-note
NONE
```
