### PR TITLE
Feature containerd option

### DIFF
--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -14,6 +14,8 @@ templates:
   config/kubeletconfig.yml.erb: config/kubeletconfig.yml
   config/openstack-ca.crt.erb: config/openstack-ca.crt
   config/service_key.json.erb: config/service_key.json
+  monit.erb: monit
+
 packages:
 - pid_utils
 - kubernetes
@@ -24,6 +26,10 @@ properties:
     description: The token to access Kubernetes API
   cloud-provider:
     description: "The type of cloud-provider that is being deployed"
+  container-runtime:
+    description: "The container runtime job can be containerd or docker"
+    default: docker
+
   drain-api-token:
     description: The token to access Kubernetes API used to drain the kubelet.
   http_proxy:
@@ -54,6 +60,7 @@ properties:
   kubelet-drain-force-node:
     description: "Forcibly terminate pods if all the pods fail to drain before the timeout."
     default: false
+
   k8s-args:
     description: "Pass-through options for Kubernetes runtime arguments. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ for reference."
     example: |

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -3,6 +3,7 @@
 NAME="${0##*/}"
 
 export PATH=/var/vcap/packages/kubernetes/bin/:/var/vcap/packages/docker/sbin/:/var/vcap/packages/socat/bin/:$PATH
+export PATH=$PATH:/var/vcap/packages/containerd/bin
 
 RUN_DIR=/var/vcap/sys/run/kubernetes
 PIDFILE=$RUN_DIR/kubelet.pid

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -4,13 +4,12 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubelet/config/kubeconfig"
-
-
-if p('container-runtime').downcase == "docker"
-   DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
-else if p('container-runtime').downcase == "containerd"
-   DOCKER_SOCKET=unix:///var/vcap/sys/run/containerd/containerd.sock
-end
+<% if p("container-runtime").eql?  "docker" %>
+DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
+<% else if p("container-runtime").eql? "containerd" %>
+DOCKER_SOCKET=unix:///var/vcap/sys/run/containerd/containerd.sock
+<% end %>
+<% end %>
 
 CONTAINER_IMAGE_DIR=/var/vcap/packages/kubernetes/container-images
 
@@ -18,11 +17,14 @@ load_container() {
     path=$1
 
     echo "loading cached container: ${path}"
-    if p('container-runtime').downcase == "containerd"
-    result = sudo ctr -n=k8s.io --address=/var/vcap/sys/run/containerd/containerd.sock images import "${path};
-    if p('container-runtime').downcase == "docker"
-    result = sudo /var/vcap/jobs/kubelet/packages/docker/bin/docker -H ${DOCKER_SOCKET} load < "${path}";
-    if $result then
+    <% if p("container-runtime").eql?  "containerd" %>
+    sudo /var/vcap/packages/containerd/bin/ctr -n=k8s.io --address=/var/vcap/sys/run/containerd/containerd.sock images import "${path}";
+    <% else if p("container-runtime").eql? "docker" %>
+    sudo /var/vcap/jobs/kubelet/packages/docker/bin/docker -H ${DOCKER_SOCKET} load < "${path}";
+    <% end %>
+    <% end %>
+    result=$?
+    if [ ${result} ]; then
       echo "successfully loaded container: ${path}"
     else
       echo "failed to load container: ${path}"
@@ -32,6 +34,11 @@ load_container() {
 
 load_cached_containers() {
     for img in ${CONTAINER_IMAGE_DIR}/*.tgz; do
+    <% if p("container-runtime").eql?  "containerd" %>
+	gunzip -k -f ${img}
+    done
+    for img in ${CONTAINER_IMAGE_DIR}/*.tar; do
+    <% end %>
         load_container ${img}
     done
 }

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -5,14 +5,24 @@
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubelet/config/kubeconfig"
 
-DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
+
+if p('container-runtime').downcase == "docker"
+   DOCKER_SOCKET=unix:///var/vcap/sys/run/docker/docker.sock
+else if p('container-runtime').downcase == "containerd"
+   DOCKER_SOCKET=unix:///var/vcap/sys/run/containerd/containerd.sock
+end
+
 CONTAINER_IMAGE_DIR=/var/vcap/packages/kubernetes/container-images
 
 load_container() {
     path=$1
 
     echo "loading cached container: ${path}"
-    if sudo /var/vcap/jobs/kubelet/packages/docker/bin/docker -H ${DOCKER_SOCKET} load < "${path}"; then
+    if p('container-runtime').downcase == "containerd"
+    result = sudo ctr -n=k8s.io --address=/var/vcap/sys/run/containerd/containerd.sock images import "${path};
+    if p('container-runtime').downcase == "docker"
+    result = sudo /var/vcap/jobs/kubelet/packages/docker/bin/docker -H ${DOCKER_SOCKET} load < "${path}";
+    if $result then
       echo "successfully loaded container: ${path}"
     else
       echo "failed to load container: ${path}"

--- a/jobs/kubelet/templates/monit.erb
+++ b/jobs/kubelet/templates/monit.erb
@@ -1,0 +1,12 @@
+check process kubelet
+  with pidfile /var/vcap/sys/run/kubernetes/kubelet.pid
+  start program "/var/vcap/jobs/kubelet/bin/kubelet_ctl start"
+  stop program "/var/vcap/jobs/kubelet/bin/kubelet_ctl stop"
+  group vcap
+  <%= if p("container-runtime").eq? "docker"
+  depends on docker
+  %>
+  <%= if p("container-runtime").eq? "containerd"
+  depends on containerd
+  %>
+

--- a/jobs/kubelet/templates/monit.erb
+++ b/jobs/kubelet/templates/monit.erb
@@ -3,10 +3,11 @@ check process kubelet
   start program "/var/vcap/jobs/kubelet/bin/kubelet_ctl start"
   stop program "/var/vcap/jobs/kubelet/bin/kubelet_ctl stop"
   group vcap
-  <%= if p("container-runtime").eq? "docker"
+  <% if p("container-runtime").eql? "docker" %>
   depends on docker
-  %>
-  <%= if p("container-runtime").eq? "containerd"
+  <% else %>
+  <% if p("container-runtime").eql? "containerd" %>
   depends on containerd
-  %>
+  <% end %>
+  <% end %>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows use containerd instead of docker. 

Why is this PR important? What is the user impact?
Containerd works better than docker. It is lighter and more efficient.
No more bug with docker. When docker crashed it filled the disk very quickly with his log and so on fill the bosh director.
**How can this PR be verified?**
Add  
**Is there any change in kubo-deployment?**
new kubelet property is added to kubelet job spec file: 
```
  container-runtime:
    description: "The container runtime job can be containerd or docker"
    default: docker
```
so by default no change in kubo-deployment
If you plan to use  containerd use these operator (with or without proxy setting)
```
- type: replace
  path: /instance_groups/name=worker/jobs/name=kubelet/properties/k8s-args/container-runtime
  value: remote

- type: replace
  path: /instance_groups/name=worker/jobs/name=kubelet/properties/k8s-args/container-runtime-endpoint?
  value: unix:///var/vcap/sys/run/containerd/containerd.sock

- type: replace
  path: /instance_groups/name=worker/jobs/name=kubelet/properties/k8s-args/runtime-request-timeout?
  value: 15m

- type: replace
  path: /instance_groups/name=worker/jobs/-
  value:
    name: containerd
    release: containerd
    properties:
      proxy:
        https: ((https_proxy))
        http: ((http_proxy))
        noproxy: ((no_proxy))
      config_toml:
        custom: |
          [plugins]
            [plugins.cgroups]
              no_prometheus = false
            [plugins.cri]
              stream_server_address = "127.0.0.1"
              stream_server_port = "0"
              enable_selinux = false
              sandbox_image = "k8s.gcr.io/pause:3.1"
              stats_collect_period = 10
              systemd_cgroup = false
              enable_tls_streaming = false
              max_container_log_line_size = 16384
              disable_proc_mount = false
              [plugins.cri.containerd]
                snapshotter = "overlayfs"
                no_pivot = false
                [plugins.cri.containerd.default_runtime]
                  runtime_type = "io.containerd.runtime.v1.linux"
                  runtime_engine = ""
                  runtime_root = ""
                [plugins.cri.containerd.untrusted_workload_runtime]
                  runtime_type = ""
                  runtime_engine = ""
                  runtime_root = ""
              [plugins.cri.cni]
                bin_dir = "/var/vcap/packages/cni/bin"
                conf_dir = "/etc/cni/net.d"
                conf_template = ""
              [plugins.cri.registry]
                [plugins.cri.registry.mirrors]
                  [plugins.cri.registry.mirrors."docker.io"]
                    endpoint = ["((registry-mirrors))"]
              [plugins.cri.x509_key_pair_streaming]
                tls_cert_file = ""
                tls_key_file = ""
            [plugins.diff-service]
              default = ["walking"]
            [plugins.linux]
              shim = "containerd-shim"
              runtime = "runc"
              runtime_root = ""
              no_shim = false
              shim_debug = false
            [plugins.opt]
              path = "/opt/containerd"
            [plugins.restart]
              interval = "10s"
            [plugins.scheduler]
              pause_threshold = 0.02
              deletion_threshold = 0
              mutation_threshold = 100
              schedule_delay = "0s"
              startup_delay = "100ms"

- type: remove
  path: /instance_groups/name=worker/jobs/name=kubelet/properties/k8s-args/docker

- type: remove
  path: /instance_groups/name=worker/jobs/name=kubelet/properties/k8s-args/docker-endpoint

- type: replace
  path: /releases/-
  value:
    name: containerd
    version: latest

```

by default the 
**Is there any change in kubo-ci?**
no 

**Does this affect upgrade, or is there any migration required?**
no

**Which issue(s) this PR fixes:**
fix https://github.com/cloudfoundry-incubator/kubo-release/issues/371

**Release note**:
```release-note
new kubelet parameter to allows use containerd instead of docker. It can switch the monit dependency from docker to containerd. 
```
