### PR TITLE
bump coredns from 1.6.6 to 1.6.9

### DIFF
--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -101,7 +101,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.6
+        image: coredns/coredns:1.6.9
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update coredns from 1.6.6 to the (currently) latest version 1.6.9

When resolving bosh-dns hostnames from within pods I noticed a "flapping" behavior where hostnames do not get resolved (major case) most of the time but "randomly" get resolved (minor case). Updating coredns to 1.6.9 solved the issue for me and hostnames get always resolved.

**How can this PR be verified?**

Try resolving bosh-dns hostnames from within a pod (e.g. with image `tutum/dnsutils`) running in the latest cfcr deployment (running coredns 1.6.6) and see it fail. Update coredns to 1.6.9 and see it work again.

**Is there any change in kubo-deployment?**

No.

**Is there any change in kubo-ci?**

No.

**Does this affect upgrade, or is there any migration required?**

No.

**Which issue(s) this PR fixes:**

**Release note**:

```release-note
NONE
```
